### PR TITLE
docs: rm `.` from "Last updated" metadata display

### DIFF
--- a/apps/web/src/pages/docs/[slug].tsx
+++ b/apps/web/src/pages/docs/[slug].tsx
@@ -53,7 +53,6 @@ export default function Post({ doc, menu }: Props) {
                   <time dateTime={doc.publishedAt}>
                     {formatDate(doc.publishedAt)}
                   </time>
-                  .
                 </div>
                 <hr className="border-neutral-200 mt-10 mb-10" />
                 <div className="prose prose-base outstatic-content docs">


### PR DESCRIPTION
This PR removes the period from the “Last updated…” metadata line in the docs.