### PR TITLE
Add a name field for Input component

### DIFF
--- a/packages/outstatic/src/components/Input/index.tsx
+++ b/packages/outstatic/src/components/Input/index.tsx
@@ -3,6 +3,7 @@ import { useFormContext, RegisterOptions } from 'react-hook-form'
 export type InputProps = {
   label?: string
   id: string
+  name?: string,
   placeholder?: string
   helperText?: string
   type?: string
@@ -31,6 +32,7 @@ export default function Input({
   placeholder = '',
   helperText,
   id,
+  name,
   type = 'text',
   readOnly = false,
   validation,
@@ -57,7 +59,7 @@ export default function Input({
           {...rest}
           className={`${sizes[inputSize].input} ${className}`}
           type={type}
-          name={id}
+          name={name}
           id={id}
           readOnly={readOnly}
           placeholder={placeholder}

--- a/packages/outstatic/src/pages/edit-collection/index.tsx
+++ b/packages/outstatic/src/pages/edit-collection/index.tsx
@@ -94,6 +94,7 @@ export default function EditCollection() {
           <Input
             label="Collection Name"
             id="name"
+            name="name"
             inputSize="medium"
             className="w-full max-w-sm md:w-80"
             placeholder="Ex: Posts"


### PR DESCRIPTION
The `Input` component adds a _name_ field in the final `input` HTML component, but it is the same as the _id_ field.

This can cause problem when we want the id to be unique (because of the `register` function from the `formContext` return value), but also the name to be the same for multiple inputs (which can be useful for dynamic forms).