### PR TITLE
feat: block github issues not-relating to confirmed bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Get Help
+    url: https://github.com/avitorio/outstatic/discussions/new?category=q-a
+    about: If you can't get something to work the way you expect, open a question in our discussion forums.
+  - name: Feature Request
+    url: https://github.com/avitorio/outstatic/discussions/new?category=ideas
+    about: 'Suggest any ideas you have using our discussion forums.'
+  - name: Bug Report
+    url: https://github.com/avitorio/outstatic/issues/new
+    about: If you've already asked for help with a problem and confirmed something is broken with Outstatic, create a bug report.


### PR DESCRIPTION
Inspired by TailwindCSS: https://github.com/tailwindlabs/tailwindcss/blob/master/.github/ISSUE_TEMPLATE/config.yml
You can preview the UI in my fork here: https://github.com/DCzajkowski/outstatic/issues/new/choose

This will limit accidental issues, that should be in discussions (like #43)