### PR TITLE
chore: add missing lint scripts

### DIFF
--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -5,6 +5,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
+    "lint": "next lint",
     "typecheck": "tsc --project tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -5,6 +5,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
+    "lint": "next lint",
     "typecheck": "tsc --project tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/outstatic/package.json
+++ b/packages/outstatic/package.json
@@ -16,7 +16,8 @@
     "dev": "tsup --watch & tailwindcss -i ./src/styles.css -o ./dist/outstatic.css --watch",
     "clean": "rm -rf dist",
     "test": "jest --passWithNoTests",
-    "typecheck": "tsc --project tsconfig.json --noEmit"
+    "typecheck": "tsc --project tsconfig.json --noEmit",
+    "lint": "TIMING=1 eslint \"src/**/*.ts*\""
   },
   "dependencies": {
     "@apollo/client": "^3.6.6",

--- a/turbo.json
+++ b/turbo.json
@@ -29,13 +29,16 @@
     "outstatic": {
       "dependsOn": [],
       "env": [
-        "VERCEL_GIT_REPO_SLUG",
-        "OST_REPO_SLUG",
-        "OST_REPO_BRANCH",
+        "NODE_ENV",
         "OST_CONTENT_PATH",
+        "OST_GITHUB_ID",
+        "OST_GITHUB_SECRET",
         "OST_MONOREPO_PATH",
+        "OST_REPO_BRANCH",
+        "OST_REPO_SLUG",
         "OST_REPO_OWNER",
-        "OST_TOKEN_SECRET"
+        "OST_TOKEN_SECRET",
+        "VERCEL_GIT_REPO_SLUG"
       ]
     }
   }


### PR DESCRIPTION
This adds linting to the `/packages/outstatic` project and also to the example and dev blogs.
