### PR TITLE
chore: Removes --shell and color from lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-FORCE_COLOR=1 pnpm run lint-staged --shell
+pnpm run lint-staged


### PR DESCRIPTION
`--shell` is carryover from older lint-staged versions, where tasks weren't parsed. This removes the `--shell` command.

This also removes `FORCE_COLOR` for better error message compatibility with github desktop

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number` Related #66
- [x] Integration tests added
- [x] Errors have a helpful link attached, see `contributing.md`

