### PR TITLE
fix: use OST_REPO_OWNER instead of current logged in user for image URLs when set

### DIFF
--- a/packages/outstatic/src/pages/api/images/index.ts
+++ b/packages/outstatic/src/pages/api/images/index.ts
@@ -12,11 +12,11 @@ export default async function handler(
 ) {
   const session = await getLoginSession(req)
 
+  const REPO_OWNER = process.env.OST_REPO_OWNER || session?.user?.login
+
   if (session?.access_token) {
     const response = await fetch(
-      `https://raw.githubusercontent.com/${
-        session?.user?.login
-      }/${REPO_SLUG}/${REPO_BRANCH}/${
+      `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_SLUG}/${REPO_BRANCH}/${
         MONOREPO_PATH ? MONOREPO_PATH + '/' : ''
       }public/${IMAGES_PATH}${req.query?.ost?.[1]}`,
       {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ x ] Related issues linked using `fixes #85`
