### PR TITLE
fix: remove unneeded slug yup validation

### DIFF
--- a/packages/outstatic/src/utils/slugRegex.test.ts
+++ b/packages/outstatic/src/utils/slugRegex.test.ts
@@ -1,0 +1,22 @@
+import { slugRegex } from './slugRegex'
+
+describe('Regex Test', () => {
+  it('should allow lowercase letters, numbers, and hyphens', () => {
+    expect(slugRegex.test('abc123')).toBe(true)
+    expect(slugRegex.test('abc-123')).toBe(true)
+    expect(slugRegex.test('a1b2c3-d4')).toBe(true)
+    expect(slugRegex.test('A1B2C3-d4')).toBe(false)
+  })
+
+  it('should not allow spaces or special characters', () => {
+    expect(slugRegex.test('a bc123')).toBe(false)
+    expect(slugRegex.test('a!b@c#1$2%3^')).toBe(false)
+  })
+
+  it('should start and end with a letter or number, not a hyphen', () => {
+    expect(slugRegex.test('abc123')).toBe(true)
+    expect(slugRegex.test('-abc123')).toBe(false)
+    expect(slugRegex.test('abc123-')).toBe(false)
+    expect(slugRegex.test('-abc123-')).toBe(false)
+  })
+})

--- a/packages/outstatic/src/utils/slugRegex.ts
+++ b/packages/outstatic/src/utils/slugRegex.ts
@@ -1,0 +1,1 @@
+export const slugRegex = /^([a-z0-9]+-)*[a-z0-9]+$/

--- a/packages/outstatic/src/utils/yup.ts
+++ b/packages/outstatic/src/utils/yup.ts
@@ -20,10 +20,6 @@ export const editDocumentSchema: yup.SchemaOf<Document> = yup.object().shape({
       /^[a-z0-9-]+$/,
       'Slugs can only contain lowercase letters, numbers and dashes.'
     )
-    .matches(
-      /^[a-z](-?[a-z])*$/,
-      'Slugs can only start and end with a letter and cannot contain two dashes in a row.'
-    )
     .required(),
   description: yup.string(),
   coverImage: yup.string()

--- a/packages/outstatic/src/utils/yup.ts
+++ b/packages/outstatic/src/utils/yup.ts
@@ -1,5 +1,6 @@
 import * as yup from 'yup'
 import { Document } from '../types'
+import { slugRegex } from './slugRegex'
 
 export const editDocumentSchema: yup.SchemaOf<Document> = yup.object().shape({
   title: yup.string().required('Title is required.'),
@@ -17,9 +18,10 @@ export const editDocumentSchema: yup.SchemaOf<Document> = yup.object().shape({
     .string()
     .matches(/^(?!new$)/, 'The word "new" is not a valid slug.')
     .matches(
-      /^[a-z0-9-]+$/,
-      'Slugs can only contain lowercase letters, numbers and dashes.'
+      slugRegex,
+      'Slug must contain only lowercase letters, numbers, and hyphens, and cannot start or end with a hyphen.'
     )
+    .max(200, 'Slugs can be a maximum of 200 characters.')
     .required(),
   description: yup.string(),
   coverImage: yup.string()


### PR DESCRIPTION
## Bug

Currently, this schema validation for document slugs:
```js
    .matches(
      /^[a-z](-?[a-z])*$/,
      'Slugs can only start and end with a letter and cannot contain two dashes in a row.'
    )
```
does not allow for any numbers in the middle of a slug. I don't see a reason for it to exist, there is already another validation for making sure it only contains valid characters. Is there a reason it was there or can it just be removed?