### PR TITLE
fix the Unexpected token `h1` error in jsx

### DIFF
--- a/apps/web/outstatic/content/docs/fetching-data.md
+++ b/apps/web/outstatic/content/docs/fetching-data.md
@@ -32,7 +32,7 @@ import { getDocuments } from 'outstatic/server'
 
 export default async function Index() {
   const posts = await getData()
-  return posts.map((post) => <h1>{post.title}</h1)
+  return posts.map((post) => <h1>{post.title}</h1>)
 }
 
 async function getData() {
@@ -51,7 +51,7 @@ async function getData() {
 import { getDocuments } from 'outstatic/server'
 
 export default function Index({ posts }) {
-  return posts.map((post) => <h1>{post.title}</h1)
+  return posts.map((post) => <h1>{post.title}</h1>)
 }
 
 export const getStaticProps = async () => {


### PR DESCRIPTION
fix the docs [fetching data](https://outstatic.com/docs/fetching-data) code block.

## error

```jsx
// error:  Unexpected token `h1`. Expected jsx identifier
return posts.map((post) => <h1>{post.title}</h1)
```

fix the jsx  identifier error in docs

```jsx
  return posts.map((post) => <h1>{post.title}</h1>)
```

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Documentation added
