### PR TITLE
fix(oauth-scopes): reduce required scopes to the minimum

### DIFF
--- a/apps/web/outstatic/content/docs/getting-started.md
+++ b/apps/web/outstatic/content/docs/getting-started.md
@@ -26,7 +26,7 @@ Before diving in, it's essential to configure GitHub Authentication for your pro
 
 - **GitHub Apps:** setup is generally more complex, providing a refined level of access and control.
 
-For those opting for GitHub Applications, please refer to the relevant [Github Apps Authentication](http://localhost:3000/docs/github-apps-authentication) documentation.
+For those opting for GitHub Apps, please refer to the relevant [GitHub Apps Authentication](http://localhost:3000/docs/github-apps-authentication) documentation.
 
 #### Setting up a GitHub OAuth Application:
 

--- a/apps/web/outstatic/content/docs/getting-started.md
+++ b/apps/web/outstatic/content/docs/getting-started.md
@@ -18,7 +18,19 @@ Requirements:
 
 - A [GitHub](https://github.com) account.
 
-Before we start, you need to setup GitHub Authentication on your project. Outstatic works with GitHub Oauth or GitHub Applications for authentication but GitHub Oauth is easier to setup. The documentation for GitHub Application is available [here](/docs/github-applications). Let's create a GitHub OAuth Application:
+### **Initiating Setup: GitHub Authentication**
+
+Before diving in, it's essential to configure GitHub Authentication for your project. Outstatic accommodates both **GitHub OAuth** and **GitHub Apps** for authentication purposes:
+
+- **GitHub OAuth:** easier and quicker to set up, ideal for simpler integrations.
+
+- **GitHub Apps:** setup is generally more complex, providing a refined level of access and control.
+
+For those opting for GitHub Applications, please refer to the relevant [Github Apps Authentication](http://localhost:3000/docs/github-apps-authentication) documentation.
+
+#### Setting up a GitHub OAuth Application:
+
+Let’s walk through the steps to create a GitHub OAuth Application, streamlining your project’s initial setup:
 
 - First go to the "Register a new OAuth application" page on GitHub by [clicking here](https://github.com/settings/applications/new).
 
@@ -183,3 +195,4 @@ OST_TOKEN_SECRET=A_RANDOM_TOKEN
 ```
 
 To learn more about all the available environment variables, see the [Environment Variables ](https://outstatic.com/docs/environment-variables)section of the docs.
+

--- a/apps/web/outstatic/content/docs/getting-started.md
+++ b/apps/web/outstatic/content/docs/getting-started.md
@@ -18,7 +18,7 @@ Requirements:
 
 - A [GitHub](https://github.com) account.
 
-Outstatic uses GitHub Oauth for authentication. Before we start you'll need to create a GitHub OAuth app:
+Before we start, you need to setup GitHub Authentication on your project. Outstatic works with GitHub Oauth or GitHub Applications for authentication but GitHub Oauth is easier to setup. The documentation for GitHub Application is available [here](/docs/github-applications). Let's create a GitHub OAuth Application:
 
 - First go to the "Register a new OAuth application" page on GitHub by [clicking here](https://github.com/settings/applications/new).
 

--- a/apps/web/outstatic/content/docs/getting-started.md
+++ b/apps/web/outstatic/content/docs/getting-started.md
@@ -26,7 +26,7 @@ Before diving in, it's essential to configure GitHub Authentication for your pro
 
 - **GitHub Apps:** setup is generally more complex, providing a refined level of access and control.
 
-For those opting for GitHub Apps, please refer to the relevant [GitHub Apps Authentication](http://localhost:3000/docs/github-apps-authentication) documentation.
+For those opting for GitHub Apps, please refer to the relevant [GitHub Apps Authentication](/docs/github-apps-authentication) documentation.
 
 #### Setting up a GitHub OAuth Application:
 

--- a/apps/web/outstatic/content/docs/github-applications.md
+++ b/apps/web/outstatic/content/docs/github-applications.md
@@ -1,0 +1,41 @@
+---
+title: 'GitHub Application'
+status: 'draft'
+author:
+  name: 'Anthony Quéré'
+  picture: 'https://avatars.githubusercontent.com/u/47711333?v=4'
+slug: 'github-application'
+description: ''
+coverImage: ''
+publishedAt: '2023-08-04T21:00:00.000Z'
+---
+
+## Use a GitHub Application
+
+GitHub Documentation recommands the usage of GitHub Applications instead of OAuth Applications as stated in [this article](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/differences-between-github-apps-and-oauth-apps).
+
+Outstatic can work with GitHub Applications as well as Oauth applications out of the box. Let's create a GitHub Application:
+
+- First go to the "Register a new OAuth application" page on GitHub by [clicking here](https://github.com/settings/apps/new).
+
+- Give your application a name, "Outstatic Blog" for example.
+
+- For **Homepage URL**, give any valid URL. You can change it later to your website URL.
+
+- For **Callback URL**, set it to `https://my-website-name.com/api/outstatic/callback` (for local developpment, localhost with a port also works).
+
+- You do not need to check anythink in the next section.
+
+- For **Permissions**, Outstatic only needs read and wite access to a specific repository. You can open "Repository permissions" and next to "Contents", select "Read and write"
+
+- In the last section. If you want to create the repository on your own account check "Only on this account" otherwise chose "Any account"
+
+- Click on **Create GitHub App**, you will be redirected to your application settings.
+
+- Copy your **Client ID** from your application settings
+
+- Generate a **Client Secret** by clicking on **Generate a new client secret**
+
+Then you only need to follow the [Getting Started Guide](/docs/getting-started) to configure your application with these values.
+
+

--- a/apps/web/outstatic/content/docs/github-applications.md
+++ b/apps/web/outstatic/content/docs/github-applications.md
@@ -36,6 +36,10 @@ Outstatic can work with GitHub Applications as well as Oauth applications out of
 
 - Generate a **Client Secret** by clicking on **Generate a new client secret**
 
+- In your application settings, click on "Install App" and click "Install" for the account/organization where you want to add the repository.
+
+- You can select to give permission to all repositories inside the account/organization but it is best to choose "Only select repositories" and add your repository there. (You can still change your app permission in the account/organization settings).
+
 Then you only need to follow the [Getting Started Guide](/docs/getting-started) to configure your application with these values.
 
 

--- a/apps/web/outstatic/content/docs/github-apps-authentication.md
+++ b/apps/web/outstatic/content/docs/github-apps-authentication.md
@@ -1,16 +1,16 @@
 ---
-title: 'GitHub Application'
+title: 'GitHub Apps Authentication'
 status: 'draft'
 author:
   name: 'Anthony Quéré'
   picture: 'https://avatars.githubusercontent.com/u/47711333?v=4'
-slug: 'github-application'
+slug: 'github-apps-authentication'
 description: ''
 coverImage: ''
 publishedAt: '2023-08-04T21:00:00.000Z'
 ---
 
-## Use a GitHub Application
+## Use Github Apps for Authentication
 
 GitHub Documentation recommands the usage of GitHub Applications instead of OAuth Applications as stated in [this article](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/differences-between-github-apps-and-oauth-apps).
 
@@ -41,5 +41,4 @@ Outstatic can work with GitHub Applications as well as Oauth applications out of
 - You can select to give permission to all repositories inside the account/organization but it is best to choose "Only select repositories" and add your repository there. (You can still change your app permission in the account/organization settings).
 
 Then you only need to follow the [Getting Started Guide](/docs/getting-started) to configure your application with these values.
-
 

--- a/apps/web/outstatic/content/docs/github-apps-authentication.md
+++ b/apps/web/outstatic/content/docs/github-apps-authentication.md
@@ -30,7 +30,7 @@ Enter any valid URL as the Homepage URL. This can be updated later to your actua
 
 #### 4\. Configure Callback URL
 
-Set the Callback URL to `https://my-website-name.com/api/outstatic/callback`. For local development, using [localhost](http://localhost) with a port is also acceptable.
+Set the Callback URL to `https://my-website-name.com/api/outstatic/callback`. For local development, you can use `http://localhost:3000/api/outstatic/callback`.
 
 #### 5\. Set Permissions
 

--- a/apps/web/outstatic/content/docs/github-apps-authentication.md
+++ b/apps/web/outstatic/content/docs/github-apps-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: 'GitHub Apps Authentication'
-status: 'draft'
+status: 'published'
 author:
   name: 'Anthony Quéré'
   picture: 'https://avatars.githubusercontent.com/u/47711333?v=4'

--- a/apps/web/outstatic/content/docs/github-apps-authentication.md
+++ b/apps/web/outstatic/content/docs/github-apps-authentication.md
@@ -7,38 +7,54 @@ author:
 slug: 'github-apps-authentication'
 description: ''
 coverImage: ''
-publishedAt: '2023-08-04T21:00:00.000Z'
+publishedAt: '2023-09-23T21:00:00.000Z'
 ---
 
 ## Use Github Apps for Authentication
 
-GitHub Documentation recommands the usage of GitHub Applications instead of OAuth Applications as stated in [this article](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/differences-between-github-apps-and-oauth-apps).
+The preferred method of integration, as suggested by [GitHub Documentation](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/differences-between-github-apps-and-oauth-apps), is the utilization of GitHub Apps over OAuth Applications. Outstatic has built-in support to seamlessly integrate with Github Apps.
 
-Outstatic can work with GitHub Applications as well as Oauth applications out of the box. Let's create a GitHub Application:
+Follow the steps below to create a new GitHub App:
 
-- First go to the "Register a new OAuth application" page on GitHub by [clicking here](https://github.com/settings/apps/new).
+#### 1\. Register a New Application
 
-- Give your application a name, "Outstatic Blog" for example.
+First go to the "Register a new GitHub App" page on GitHub by [clicking here](https://github.com/settings/apps/new).
 
-- For **Homepage URL**, give any valid URL. You can change it later to your website URL.
+#### 2\. Name Your Application
 
-- For **Callback URL**, set it to `https://my-website-name.com/api/outstatic/callback` (for local developpment, localhost with a port also works).
+Enter a name for your application, such as "Outstatic Blog".
 
-- You do not need to check anythink in the next section.
+#### 3\. Set Homepage URL
 
-- For **Permissions**, Outstatic only needs read and wite access to a specific repository. You can open "Repository permissions" and next to "Contents", select "Read and write"
+Enter any valid URL as the Homepage URL. This can be updated later to your actual website URL.
 
-- In the last section. If you want to create the repository on your own account check "Only on this account" otherwise chose "Any account"
+#### 4\. Configure Callback URL
 
-- Click on **Create GitHub App**, you will be redirected to your application settings.
+Set the Callback URL to `https://my-website-name.com/api/outstatic/callback`. For local development, using [localhost](http://localhost) with a port is also acceptable.
 
-- Copy your **Client ID** from your application settings
+#### 5\. Set Permissions
 
-- Generate a **Client Secret** by clicking on **Generate a new client secret**
+Outstatic requires read and write access to specific repositories. Navigate to "Repository permissions" and enable "Read and write" access next to "Contents". No other permissions are needed.
 
-- In your application settings, click on "Install App" and click "Install" for the account/organization where you want to add the repository.
+#### 6\. Select Account Scope
 
-- You can select to give permission to all repositories inside the account/organization but it is best to choose "Only select repositories" and add your repository there. (You can still change your app permission in the account/organization settings).
+In the last section, select "Only on this account" if you are creating a repository on your personal account. For creating on other accounts, choose "Any account".
+
+#### 7\. Create GitHub App
+
+Click "Create GitHub App". You will be redirected to your application settings.
+
+#### 8\. Retrieve Client ID & Generate Client Secret
+
+Copy the Client ID from your application settings and generate a Client Secret by selecting "Generate a new client secret". These will be used for `OST_GITHUB_ID` and `OST_GITHUB_SECRET` respectively.
+
+#### 9\. Install the Application
+
+Go to "Install App" in your application settings and click "Install" for the account/organization where you want to add the repository.
+
+#### 10\. Set Repository Permissions
+
+Although providing permission to all repositories is possible, it is recommended to choose "Only select repositories" and add your desired repository. This permission can be modified later in the account/organization settings.
 
 Then you only need to follow the [Getting Started Guide](/docs/getting-started) to configure your application with these values.
 

--- a/apps/web/outstatic/content/metadata.json
+++ b/apps/web/outstatic/content/metadata.json
@@ -1,6 +1,6 @@
 {
-  "commit": "269d0ef2ff2d99fedb4de57b161f41e7aad2ee38",
-  "generated": "2023-09-23T20:36:57.044Z",
+  "commit": "0203755b3e71110daa0f698a949d9908ce70e8ac",
+  "generated": "2023-09-23T20:39:35.216Z",
   "metadata": [
     {
       "__outstatic": {
@@ -201,24 +201,6 @@
     },
     {
       "__outstatic": {
-        "commit": "1c34206dd01f8e6882c3ab37f0216222b3726d14",
-        "hash": "1438836947",
-        "path": "outstatic/content/docs/github-apps-authentication.md"
-      },
-      "author": {
-        "name": "Anthony Quéré",
-        "picture": "https://avatars.githubusercontent.com/u/47711333?v=4"
-      },
-      "collection": "docs",
-      "coverImage": "",
-      "description": "",
-      "publishedAt": "2023-09-23T21:00:00.000Z",
-      "slug": "github-apps-authentication",
-      "status": "published",
-      "title": "GitHub Apps Authentication"
-    },
-    {
-      "__outstatic": {
         "commit": "269d0ef2ff2d99fedb4de57b161f41e7aad2ee38",
         "hash": "3824145684",
         "path": "outstatic/content/docs/getting-started.md"
@@ -234,6 +216,24 @@
       "slug": "getting-started",
       "status": "published",
       "title": "Getting started"
+    },
+    {
+      "__outstatic": {
+        "commit": "0203755b3e71110daa0f698a949d9908ce70e8ac",
+        "hash": "2432495499",
+        "path": "outstatic/content/docs/github-apps-authentication.md"
+      },
+      "author": {
+        "name": "Anthony Quéré",
+        "picture": "https://avatars.githubusercontent.com/u/47711333?v=4"
+      },
+      "collection": "docs",
+      "coverImage": "",
+      "description": "",
+      "publishedAt": "2023-09-23T21:00:00.000Z",
+      "slug": "github-apps-authentication",
+      "status": "published",
+      "title": "GitHub Apps Authentication"
     }
   ]
 }

--- a/apps/web/outstatic/content/metadata.json
+++ b/apps/web/outstatic/content/metadata.json
@@ -1,6 +1,6 @@
 {
   "commit": "be5c6708424ebff6c0ba0fc2b0bdf5bc1d101b12",
-  "generated": "2023-09-23T19:10:19.760Z",
+  "generated": "2023-09-23T19:11:31.766Z",
   "metadata": [
     {
       "__outstatic": {
@@ -220,7 +220,7 @@
     {
       "__outstatic": {
         "commit": "be5c6708424ebff6c0ba0fc2b0bdf5bc1d101b12",
-        "hash": "1391498526",
+        "hash": "3827089184",
         "path": "outstatic/content/docs/github-apps-authentication.md"
       },
       "author": {
@@ -232,7 +232,7 @@
       "description": "",
       "publishedAt": "2023-08-04T21:00:00.000Z",
       "slug": "github-apps-authentication",
-      "status": "draft",
+      "status": "published",
       "title": "GitHub Apps Authentication"
     }
   ]

--- a/apps/web/outstatic/content/metadata.json
+++ b/apps/web/outstatic/content/metadata.json
@@ -1,6 +1,6 @@
 {
-  "commit": "be5c6708424ebff6c0ba0fc2b0bdf5bc1d101b12",
-  "generated": "2023-09-23T19:11:31.766Z",
+  "commit": "0978df52e1b56a052907bd2336424ad9e4701f01",
+  "generated": "2023-09-23T19:20:52.514Z",
   "metadata": [
     {
       "__outstatic": {
@@ -91,24 +91,6 @@
       "slug": "faqs",
       "status": "published",
       "title": "FAQs"
-    },
-    {
-      "__outstatic": {
-        "commit": "9e4fdd9014f3e9aa0907d4831dd32fb2a4a323cd",
-        "hash": "4070692543",
-        "path": "/outstatic/content/docs/getting-started.md"
-      },
-      "author": {
-        "name": "Andre Vitorio",
-        "picture": "https://avatars.githubusercontent.com/u/1417109?v=4"
-      },
-      "collection": "docs",
-      "coverImage": "",
-      "description": "",
-      "publishedAt": "2023-09-23T18:34:15.000Z",
-      "slug": "getting-started",
-      "status": "published",
-      "title": "Getting started"
     },
     {
       "__outstatic": {
@@ -234,6 +216,24 @@
       "slug": "github-apps-authentication",
       "status": "published",
       "title": "GitHub Apps Authentication"
+    },
+    {
+      "__outstatic": {
+        "commit": "0978df52e1b56a052907bd2336424ad9e4701f01",
+        "hash": "3743127163",
+        "path": "outstatic/content/docs/getting-started.md"
+      },
+      "author": {
+        "name": "Andre Vitorio",
+        "picture": "https://avatars.githubusercontent.com/u/1417109?v=4"
+      },
+      "collection": "docs",
+      "coverImage": "",
+      "description": "",
+      "publishedAt": "2023-09-23T18:34:15.000Z",
+      "slug": "getting-started",
+      "status": "published",
+      "title": "Getting started"
     }
   ]
 }

--- a/apps/web/outstatic/content/metadata.json
+++ b/apps/web/outstatic/content/metadata.json
@@ -1,6 +1,6 @@
 {
-  "commit": "82f4d266ba8f48cad7a79409de0861a449ebadd3",
-  "generated": "Sat, 23 Sep 2023 19:04:16 GMT",
+  "commit": "be5c6708424ebff6c0ba0fc2b0bdf5bc1d101b12",
+  "generated": "2023-09-23T19:10:19.760Z",
   "metadata": [
     {
       "__outstatic": {
@@ -216,6 +216,24 @@
       "slug": "using-with-next-js-12",
       "status": "draft",
       "title": "Using with Next.js 12"
+    },
+    {
+      "__outstatic": {
+        "commit": "be5c6708424ebff6c0ba0fc2b0bdf5bc1d101b12",
+        "hash": "1391498526",
+        "path": "outstatic/content/docs/github-apps-authentication.md"
+      },
+      "author": {
+        "name": "Anthony Quéré",
+        "picture": "https://avatars.githubusercontent.com/u/47711333?v=4"
+      },
+      "collection": "docs",
+      "coverImage": "",
+      "description": "",
+      "publishedAt": "2023-08-04T21:00:00.000Z",
+      "slug": "github-apps-authentication",
+      "status": "draft",
+      "title": "GitHub Apps Authentication"
     }
   ]
 }

--- a/apps/web/outstatic/content/metadata.json
+++ b/apps/web/outstatic/content/metadata.json
@@ -1,7 +1,25 @@
 {
-  "commit": "4bd16341cea9c4e431916ee6afad9e57c5b657ee",
-  "generated": "2023-09-23T17:35:23.661Z",
+  "commit": "82f4d266ba8f48cad7a79409de0861a449ebadd3",
+  "generated": "Sat, 23 Sep 2023 19:04:16 GMT",
   "metadata": [
+    {
+      "__outstatic": {
+        "commit": "f88e9cbc1e92098f47f24353f52ec2e379ff17dc",
+        "hash": "1802544230",
+        "path": "/outstatic/content/docs/environment-variables.md"
+      },
+      "author": {
+        "name": "Andre Vitorio",
+        "picture": "https://avatars.githubusercontent.com/u/1417109?v=4"
+      },
+      "collection": "docs",
+      "coverImage": "",
+      "description": "",
+      "publishedAt": "2022-10-13T12:36:25.000Z",
+      "slug": "environment-variables",
+      "status": "published",
+      "title": "Environment variables"
+    },
     {
       "__outstatic": {
         "commit": "28fb2f86179c26f5063364ced8395466b6f7985c",
@@ -40,39 +58,21 @@
     },
     {
       "__outstatic": {
-        "commit": "22650aab8e1fa8241dd7756b1bf90fd79342969d",
-        "hash": "3223339599",
-        "path": "/outstatic/content/docs/fetching-data.md"
+        "commit": "d284432c4f249abdc1b70341c757a5fef958f7ae",
+        "hash": "233056259",
+        "path": "/outstatic/content/docs/github-applications.md"
       },
       "author": {
-        "name": "Jakob Heuser",
-        "picture": "https://avatars.githubusercontent.com/u/1795?v=4"
+        "name": "Anthony Quéré",
+        "picture": "https://avatars.githubusercontent.com/u/47711333?v=4"
       },
       "collection": "docs",
       "coverImage": "",
       "description": "",
-      "publishedAt": "2023-07-25T12:28:25.000Z",
-      "slug": "fetching-data",
-      "status": "published",
-      "title": "Fetching data"
-    },
-    {
-      "__outstatic": {
-        "commit": "f88e9cbc1e92098f47f24353f52ec2e379ff17dc",
-        "hash": "1802544230",
-        "path": "/outstatic/content/docs/environment-variables.md"
-      },
-      "author": {
-        "name": "Andre Vitorio",
-        "picture": "https://avatars.githubusercontent.com/u/1417109?v=4"
-      },
-      "collection": "docs",
-      "coverImage": "",
-      "description": "",
-      "publishedAt": "2022-10-13T12:36:25.000Z",
-      "slug": "environment-variables",
-      "status": "published",
-      "title": "Environment variables"
+      "publishedAt": "2023-08-04T21:00:00.000Z",
+      "slug": "github-application",
+      "status": "draft",
+      "title": "GitHub Application"
     },
     {
       "__outstatic": {
@@ -94,20 +94,39 @@
     },
     {
       "__outstatic": {
-        "commit": "a36a42a309ed2ca9176c49ce0302bf005243b928",
-        "hash": "3142407191",
-        "path": "/outstatic/content/posts/how-to-create-a-blog-with-outstatic.md"
+        "commit": "9e4fdd9014f3e9aa0907d4831dd32fb2a4a323cd",
+        "hash": "4070692543",
+        "path": "/outstatic/content/docs/getting-started.md"
       },
       "author": {
-        "name": "Andre Vitorio"
+        "name": "Andre Vitorio",
+        "picture": "https://avatars.githubusercontent.com/u/1417109?v=4"
       },
-      "collection": "posts",
-      "coverImage": "/images/outstatic-demo.png",
-      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.",
-      "publishedAt": "2022-07-14T02:34:02.322Z",
-      "slug": "how-to-create-a-blog-with-outstatic",
+      "collection": "docs",
+      "coverImage": "",
+      "description": "",
+      "publishedAt": "2023-09-23T18:34:15.000Z",
+      "slug": "getting-started",
       "status": "published",
-      "title": "Learn how to create your blog with Outstatic"
+      "title": "Getting started"
+    },
+    {
+      "__outstatic": {
+        "commit": "22650aab8e1fa8241dd7756b1bf90fd79342969d",
+        "hash": "3223339599",
+        "path": "/outstatic/content/docs/fetching-data.md"
+      },
+      "author": {
+        "name": "Jakob Heuser",
+        "picture": "https://avatars.githubusercontent.com/u/1795?v=4"
+      },
+      "collection": "docs",
+      "coverImage": "",
+      "description": "",
+      "publishedAt": "2023-07-25T12:28:25.000Z",
+      "slug": "fetching-data",
+      "status": "published",
+      "title": "Fetching data"
     },
     {
       "__outstatic": {
@@ -126,6 +145,23 @@
       "slug": "docs-menu",
       "status": "published",
       "title": "Docs Menu"
+    },
+    {
+      "__outstatic": {
+        "commit": "a36a42a309ed2ca9176c49ce0302bf005243b928",
+        "hash": "3142407191",
+        "path": "/outstatic/content/posts/how-to-create-a-blog-with-outstatic.md"
+      },
+      "author": {
+        "name": "Andre Vitorio"
+      },
+      "collection": "posts",
+      "coverImage": "/images/outstatic-demo.png",
+      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.",
+      "publishedAt": "2022-07-14T02:34:02.322Z",
+      "slug": "how-to-create-a-blog-with-outstatic",
+      "status": "published",
+      "title": "Learn how to create your blog with Outstatic"
     },
     {
       "__outstatic": {
@@ -165,9 +201,9 @@
     },
     {
       "__outstatic": {
-        "commit": "45ca9e42f40af5b62cae3238db8e59ff4f4773ab",
+        "commit": "07a1c5d4917cb890b42c9c65d7438d8b03900e6b",
         "hash": "2303996183",
-        "path": "outstatic/content/docs/using-with-next-js-12.md"
+        "path": "/outstatic/content/docs/using-with-next-js-12.md"
       },
       "author": {
         "name": "Andre Vitorio",
@@ -180,24 +216,6 @@
       "slug": "using-with-next-js-12",
       "status": "draft",
       "title": "Using with Next.js 12"
-    },
-    {
-      "__outstatic": {
-        "commit": "4bd16341cea9c4e431916ee6afad9e57c5b657ee",
-        "hash": "4081880286",
-        "path": "outstatic/content/docs/getting-started.md"
-      },
-      "author": {
-        "name": "Andre Vitorio",
-        "picture": "https://avatars.githubusercontent.com/u/1417109?v=4"
-      },
-      "collection": "docs",
-      "coverImage": "",
-      "description": "",
-      "publishedAt": "2023-09-23T18:34:15.000Z",
-      "slug": "getting-started",
-      "status": "published",
-      "title": "Getting started"
     }
   ]
 }

--- a/apps/web/outstatic/content/metadata.json
+++ b/apps/web/outstatic/content/metadata.json
@@ -1,6 +1,6 @@
 {
-  "commit": "0203755b3e71110daa0f698a949d9908ce70e8ac",
-  "generated": "2023-09-23T20:39:35.216Z",
+  "commit": "fec08610d176b40d8e7ced1e524a00748eab8323",
+  "generated": "2023-09-23T20:49:32.407Z",
   "metadata": [
     {
       "__outstatic": {
@@ -201,24 +201,6 @@
     },
     {
       "__outstatic": {
-        "commit": "269d0ef2ff2d99fedb4de57b161f41e7aad2ee38",
-        "hash": "3824145684",
-        "path": "outstatic/content/docs/getting-started.md"
-      },
-      "author": {
-        "name": "Andre Vitorio",
-        "picture": "https://avatars.githubusercontent.com/u/1417109?v=4"
-      },
-      "collection": "docs",
-      "coverImage": "",
-      "description": "",
-      "publishedAt": "2023-09-23T18:34:15.000Z",
-      "slug": "getting-started",
-      "status": "published",
-      "title": "Getting started"
-    },
-    {
-      "__outstatic": {
         "commit": "0203755b3e71110daa0f698a949d9908ce70e8ac",
         "hash": "2432495499",
         "path": "outstatic/content/docs/github-apps-authentication.md"
@@ -234,6 +216,24 @@
       "slug": "github-apps-authentication",
       "status": "published",
       "title": "GitHub Apps Authentication"
+    },
+    {
+      "__outstatic": {
+        "commit": "fec08610d176b40d8e7ced1e524a00748eab8323",
+        "hash": "2000599834",
+        "path": "outstatic/content/docs/getting-started.md"
+      },
+      "author": {
+        "name": "Andre Vitorio",
+        "picture": "https://avatars.githubusercontent.com/u/1417109?v=4"
+      },
+      "collection": "docs",
+      "coverImage": "",
+      "description": "",
+      "publishedAt": "2023-09-23T18:34:15.000Z",
+      "slug": "getting-started",
+      "status": "published",
+      "title": "Getting started"
     }
   ]
 }

--- a/apps/web/outstatic/content/metadata.json
+++ b/apps/web/outstatic/content/metadata.json
@@ -1,6 +1,6 @@
 {
-  "commit": "0978df52e1b56a052907bd2336424ad9e4701f01",
-  "generated": "2023-09-23T19:20:52.514Z",
+  "commit": "1c34206dd01f8e6882c3ab37f0216222b3726d14",
+  "generated": "2023-09-23T19:27:01.861Z",
   "metadata": [
     {
       "__outstatic": {
@@ -201,24 +201,6 @@
     },
     {
       "__outstatic": {
-        "commit": "be5c6708424ebff6c0ba0fc2b0bdf5bc1d101b12",
-        "hash": "3827089184",
-        "path": "outstatic/content/docs/github-apps-authentication.md"
-      },
-      "author": {
-        "name": "Anthony Quéré",
-        "picture": "https://avatars.githubusercontent.com/u/47711333?v=4"
-      },
-      "collection": "docs",
-      "coverImage": "",
-      "description": "",
-      "publishedAt": "2023-08-04T21:00:00.000Z",
-      "slug": "github-apps-authentication",
-      "status": "published",
-      "title": "GitHub Apps Authentication"
-    },
-    {
-      "__outstatic": {
         "commit": "0978df52e1b56a052907bd2336424ad9e4701f01",
         "hash": "3743127163",
         "path": "outstatic/content/docs/getting-started.md"
@@ -234,6 +216,24 @@
       "slug": "getting-started",
       "status": "published",
       "title": "Getting started"
+    },
+    {
+      "__outstatic": {
+        "commit": "1c34206dd01f8e6882c3ab37f0216222b3726d14",
+        "hash": "1438836947",
+        "path": "outstatic/content/docs/github-apps-authentication.md"
+      },
+      "author": {
+        "name": "Anthony Quéré",
+        "picture": "https://avatars.githubusercontent.com/u/47711333?v=4"
+      },
+      "collection": "docs",
+      "coverImage": "",
+      "description": "",
+      "publishedAt": "2023-09-23T21:00:00.000Z",
+      "slug": "github-apps-authentication",
+      "status": "published",
+      "title": "GitHub Apps Authentication"
     }
   ]
 }

--- a/apps/web/outstatic/content/metadata.json
+++ b/apps/web/outstatic/content/metadata.json
@@ -1,6 +1,6 @@
 {
-  "commit": "1c34206dd01f8e6882c3ab37f0216222b3726d14",
-  "generated": "2023-09-23T19:27:01.861Z",
+  "commit": "269d0ef2ff2d99fedb4de57b161f41e7aad2ee38",
+  "generated": "2023-09-23T20:36:57.044Z",
   "metadata": [
     {
       "__outstatic": {
@@ -201,24 +201,6 @@
     },
     {
       "__outstatic": {
-        "commit": "0978df52e1b56a052907bd2336424ad9e4701f01",
-        "hash": "3743127163",
-        "path": "outstatic/content/docs/getting-started.md"
-      },
-      "author": {
-        "name": "Andre Vitorio",
-        "picture": "https://avatars.githubusercontent.com/u/1417109?v=4"
-      },
-      "collection": "docs",
-      "coverImage": "",
-      "description": "",
-      "publishedAt": "2023-09-23T18:34:15.000Z",
-      "slug": "getting-started",
-      "status": "published",
-      "title": "Getting started"
-    },
-    {
-      "__outstatic": {
         "commit": "1c34206dd01f8e6882c3ab37f0216222b3726d14",
         "hash": "1438836947",
         "path": "outstatic/content/docs/github-apps-authentication.md"
@@ -234,6 +216,24 @@
       "slug": "github-apps-authentication",
       "status": "published",
       "title": "GitHub Apps Authentication"
+    },
+    {
+      "__outstatic": {
+        "commit": "269d0ef2ff2d99fedb4de57b161f41e7aad2ee38",
+        "hash": "3824145684",
+        "path": "outstatic/content/docs/getting-started.md"
+      },
+      "author": {
+        "name": "Andre Vitorio",
+        "picture": "https://avatars.githubusercontent.com/u/1417109?v=4"
+      },
+      "collection": "docs",
+      "coverImage": "",
+      "description": "",
+      "publishedAt": "2023-09-23T18:34:15.000Z",
+      "slug": "getting-started",
+      "status": "published",
+      "title": "Getting started"
     }
   ]
 }

--- a/packages/outstatic/src/app/api/auth/login.ts
+++ b/packages/outstatic/src/app/api/auth/login.ts
@@ -1,7 +1,11 @@
 import { redirect } from 'next/navigation'
 
 export default async function GET() {
+  const scopes = ['read:user', 'repo']
+
   redirect(
-    `https://github.com/login/oauth/authorize?client_id=${process.env.OST_GITHUB_ID}&scope=repo%2C%20user&response_type=code`
+    `https://github.com/login/oauth/authorize?client_id=${
+      process.env.OST_GITHUB_ID
+    }&scope=${scopes.join('%20')}&response_type=code`
   )
 }

--- a/packages/outstatic/src/app/api/auth/login.ts
+++ b/packages/outstatic/src/app/api/auth/login.ts
@@ -3,9 +3,11 @@ import { redirect } from 'next/navigation'
 export default async function GET() {
   const scopes = ['read:user', 'repo']
 
-  redirect(
-    `https://github.com/login/oauth/authorize?client_id=${
-      process.env.OST_GITHUB_ID
-    }&scope=${scopes.join('%20')}&response_type=code`
-  )
+  const url = new URL('https://github.com/login/oauth/authorize')
+
+  url.searchParams.append('client_id', process.env.OST_GITHUB_ID ?? '')
+  url.searchParams.append('scopes', scopes.join(' '))
+  url.searchParams.append('response_type', 'code')
+
+  redirect(url.toString())
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Currently, the Outstatic documentation says to create an Oauth application to manage user authentication. 
This is great but GitHub recommends the usage of GitHub application instead which provides Fine Grained access to resources and can limit Outstatic accesses to a single repository (if needed). 

**Changes :** 
- Documentation about GitHub Application added
- Reduce OAuth scopes to only "read:user" and "repo"

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have a helpful link attached, see `contributing.md`
