### PR TITLE
Use OST_REPO_OWNER when deleting a collection

### DIFF
--- a/.changeset/flat-comics-clean.md
+++ b/.changeset/flat-comics-clean.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Use OST_REPO_OWNER when deleting a collection

--- a/packages/outstatic/src/client/pages/collections.tsx
+++ b/packages/outstatic/src/client/pages/collections.tsx
@@ -26,7 +26,7 @@ export default function Collections() {
   const deleteCollection = async (collection: string) => {
     try {
       const oid = await fetchOid()
-      const owner = session?.user?.login || ''
+      const owner = process.env.OST_REPO_OWNER || session?.user?.login || ''
 
       const commitInput = collectionCommitInput({
         owner,


### PR DESCRIPTION
Use OST_REPO_OWNER when deleting a collection. 
Otherwise breaks deleting a collection if Repo Owner is different than logged in user. 

See image for current error (endless spinning when trying to delete)
![image](https://github.com/avitorio/outstatic/assets/23730603/8f4d51b0-b004-4f97-9684-e4b943f2021c)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Errors have a helpful link attached, see `contributing.md`
