### PR TITLE
fix: upload Cover Image file error for Safari Browser

### DIFF
--- a/.changeset/shiny-hats-knock.md
+++ b/.changeset/shiny-hats-knock.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+"outstatic": patch
 ---
 
 fix: upload Cover Image file error for Safari Browser

--- a/.changeset/shiny-hats-knock.md
+++ b/.changeset/shiny-hats-knock.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+fix: upload Cover Image file error for Safari Browser

--- a/packages/outstatic/src/components/DocumentSettingsImageSelection/index.tsx
+++ b/packages/outstatic/src/components/DocumentSettingsImageSelection/index.tsx
@@ -49,7 +49,6 @@ const DocumentSettingsImageSelection = ({
       const file = currentTarget.files[0]
       const blob = URL.createObjectURL(file)
       editDocument(name, blob)
-      setShowImage(true)
       const reader = new FileReader()
       reader.readAsArrayBuffer(file)
       reader.onloadend = () => {


### PR DESCRIPTION
ShowImage boolean was being set to true before the file is read. This triggered the OnError() callback of the img tag in Safari.

Below are screenshots of what the console looked like when the setShowImage(true) was there (I added logs for tracing):

Safari
![Screen Shot 2023-10-15 at 3 35 21 AM](https://github.com/avitorio/outstatic/assets/137479354/f2d45ee3-9b6b-4029-a093-ff67be7dbda8)

Chrome
![Screen Shot 2023-10-15 at 3 35 55 AM](https://github.com/avitorio/outstatic/assets/137479354/985c299f-007f-485c-a150-06e903687f3c)

For some reason Google Chrome, does not complain about this.

After removing the extra setShowImage(true) line, upload cover image using a file works for both Chrome and Safari.


<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x ] Related issues linked using `fixes #135`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
