### PR TITLE
fix: author name check

### DIFF
--- a/.changeset/hot-dragons-fix.md
+++ b/.changeset/hot-dragons-fix.md
@@ -1,0 +1,5 @@
+---
+"outstatic": patch
+---
+
+fix: author name check

--- a/packages/outstatic/src/components/DocumentSettings/index.tsx
+++ b/packages/outstatic/src/components/DocumentSettings/index.tsx
@@ -155,7 +155,7 @@ const DocumentSettings = ({
             label="Name"
             name="author.name"
             id="author.name"
-            defaultValue={document.author?.name}
+            defaultValue={document.author?.name ?? ""}
             inputSize="small"
             wrapperClass="mb-4"
           />

--- a/packages/outstatic/src/components/DocumentSettings/test.tsx
+++ b/packages/outstatic/src/components/DocumentSettings/test.tsx
@@ -1,6 +1,11 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
-import { TestWrapper } from '../../utils/TestWrapper'
+
+import {
+  TestWrapper,
+  TestProviders,
+  documentExample
+} from '../../utils/TestWrapper'
 import { useOstSession } from '../../utils/auth/hooks'
 import DocumentSettings from '.'
 
@@ -34,5 +39,35 @@ describe('<DocumentSettings />', () => {
     )
 
     expect(screen.getByText('July 14, 2022')).toBeInTheDocument()
+  })
+  it('should handle empty author name', async () => {
+    ;(useOstSession as jest.Mock).mockReturnValue({
+      session: {
+        user: {
+          username: 'avitorio'
+        }
+      },
+      status: 'authenticated'
+    })
+
+    render(
+      <TestProviders.Apollo>
+        <TestProviders.DocumentContext
+          value={{
+            document: { ...documentExample, author: { name: undefined } }
+          }}
+        >
+          <TestProviders.Form>
+            <DocumentSettings
+              saveFunc={() => {}}
+              loading={false}
+              showDelete={false}
+            />
+          </TestProviders.Form>
+        </TestProviders.DocumentContext>
+      </TestProviders.Apollo>
+    )
+    expect(screen.getByLabelText('Name')).toHaveValue('')
+    expect(screen.getByLabelText('Name')).not.toBeUndefined()
   })
 })

--- a/packages/outstatic/src/utils/hooks/useDocumentUpdateEffect.tsx
+++ b/packages/outstatic/src/utils/hooks/useDocumentUpdateEffect.tsx
@@ -61,7 +61,7 @@ export const useDocumentUpdateEffect = ({
         methods.reset({
           ...formData,
           author: {
-            name: session?.user.name,
+            name: session?.user.name ?? '',
             picture: session?.user.image ?? ''
           },
           coverImage: '',


### PR DESCRIPTION
# Description
1. Actual code change is very light, a lot of the PR comes from me trying to replicate the test case to prove the change worked
```sh
# Actual files changed
packages/outstatic/src/components/DocumentSettings/index.tsx
packages/outstatic/src/utils/hooks/useDocumentUpdateEffect.tsx
```

2. `<TestWrapper>` extensions
I just extended the providers to be accessible so that if I want to manipulate them in my test, it's easier to do so (happy though to follow your lead on this). My end goal is to just show that when the payload received is `undefined`, the component is resilent enough to take cafe of it.

3. I didn't touch the code at the mutation level (so `setLoginSession`) cause I wasn't sure if there's any other side effect of `author.name` being `undefined` might bring. So instead I opted in to handle it at the form / component level since I can test it (happy again to follow your lead on this one).

# Linting, typechecking and testing

```sh
pnpm run typecheck

> outstatic@1.0.4 typecheck /Users/knd/Code/personal/outstatic-1/packages/outstatic
> tsc --project tsconfig.json --noEmit

pnpm run test

> outstatic@1.0.4 test /Users/knd/Code/personal/outstatic-1/packages/outstatic
> jest --passWithNoTests

watchman warning:  Recrawled this watch 3 times, most recently because:
MustScanSubDirs UserDroppedTo resolve, please review the information on
https://facebook.github.io/watchman/docs/troubleshooting.html#recrawl
To clear this warning, run:
`watchman watch-del '/Users/knd/Code/personal' ; watchman watch-project '/Users/knd/Code/personal'`

 PASS  src/utils/slugRegex.test.ts
 PASS  src/components/Sidebar/test.tsx
 PASS  src/app/index.test.tsx
 PASS  src/components/MDEMenuButton/test.tsx
 PASS  src/components/DocumentsTable/test.tsx
 PASS  src/components/MDEImageMenu/test.tsx
 PASS  src/components/DateTimePicker/test.tsx
 PASS  src/components/Modal/test.tsx
 PASS  src/components/DeleteDocumentButton/test.tsx
 PASS  src/components/MDEMenu/test.tsx
 PASS  src/components/DocumentSettings/test.tsx
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------|---------|----------|---------|---------|-------------------
All files |   14.08 |    12.57 |    12.8 |   14.25 |
 src      |       0 |        0 |       0 |       0 |
  ....tsx |       0 |        0 |       0 |       0 |
 src/app  |   93.33 |    52.77 |     100 |   93.33 |
  ....tsx |   93.33 |    52.77 |     100 |   93.33 | 29
 ...p/api |       0 |      100 |       0 |       0 |
  ....tsx |       0 |      100 |       0 |       0 | 26-47
 .../auth |       0 |        0 |       0 |       0 |
  ...k.ts |       0 |        0 |       0 |       0 | 24-171
  ...n.ts |       0 |        0 |       0 |       0 | 4-15
  ...t.ts |       0 |      100 |       0 |       0 | 6-12
  user.ts |       0 |      100 |       0 |       0 | 14-18
 ...erate |       0 |        0 |       0 |       0 |
  ....tsx |       0 |        0 |       0 |       0 | 6-48
 ...mages |       0 |        0 |       0 |       0 |
  ...x.ts |       0 |        0 |       0 |       0 | 5-45
 ...lient |       0 |        0 |       0 |       0 |
  ....tsx |       0 |        0 |       0 |       0 |
 ...pages |       0 |        0 |       0 |       0 |
  404.tsx |       0 |      100 |       0 |       0 | 2
  ....tsx |       0 |        0 |       0 |       0 | 20-223
  ....tsx |       0 |        0 |       0 |       0 | 22-64
  ....tsx |       0 |        0 |       0 |       0 | 19-80
  ....tsx |       0 |        0 |       0 |       0 | 10-74
  ....tsx |       0 |        0 |       0 |       0 | 8-34
  ....tsx |       0 |        0 |       0 |       0 | 16-108
 ...field |       0 |        0 |       0 |       0 |
  ....tsx |       0 |        0 |       0 |       0 | 26-608
 ...ument |       0 |        0 |       0 |       0 |
  ....tsx |       0 |        0 |       0 |       0 | 26-94
 ...ction |       0 |        0 |       0 |       0 |
  ....tsx |       0 |        0 |       0 |       0 | 28-122
 ...nents |       0 |        0 |       0 |       0 |
  ...x.ts |       0 |        0 |       0 |       0 |
 ...rdion |   57.14 |    44.44 |      50 |   57.14 |
  ....tsx |   57.14 |    44.44 |      50 |   57.14 | 19-21
 ...eader |      20 |        0 |       0 |      20 |
  ....tsx |      20 |        0 |       0 |      20 | 20-92
 ...ayout |       0 |        0 |       0 |       0 |
  ....tsx |       0 |        0 |       0 |       0 | 23-37
 ...Alert |       0 |      100 |       0 |       0 |
  ....tsx |       0 |      100 |       0 |       0 | 6-14
 ...Block |       0 |      100 |       0 |       0 |
  ....tsx |       0 |      100 |       0 |       0 | 20-41
 ...icker |   55.55 |       75 |   27.27 |   55.55 |
  ....tsx |   55.55 |       75 |   27.27 |   55.55 | 19,24,79-110
 ...utton |   75.75 |    57.14 |    62.5 |   77.41 |
  ....tsx |   75.75 |    57.14 |    62.5 |   77.41 | 72-78,92,117
 ...tings |   35.29 |    37.03 |   16.66 |   35.29 |
  ....tsx |   35.29 |    37.03 |   16.66 |   35.29 | 79-222
 ...ction |   44.18 |       60 |   36.36 |   44.18 |
  ....tsx |   44.18 |       60 |   36.36 |   44.18 | 49-52,86-155
 ...Input |       0 |        0 |       0 |       0 |
  ....tsx |       0 |        0 |       0 |       0 | 33-61
 ...Table |     100 |      100 |     100 |     100 |
  ....tsx |     100 |      100 |     100 |     100 |
 ...Input |     100 |    53.84 |     100 |     100 |
  ....tsx |     100 |    53.84 |     100 |     100 | 39,71-76
 ...eMenu |   21.73 |    26.08 |    8.33 |   21.73 |
  ....tsx |   21.73 |    26.08 |    8.33 |   21.73 | ...6,50-53,62-175
 ...EMenu |    23.8 |       20 |   11.11 |    23.8 |
  ....tsx |    23.8 |       20 |   11.11 |    23.8 | ...5,40-41,55-194
 ...utton |    62.5 |    71.42 |      50 |    62.5 |
  ....tsx |    62.5 |    71.42 |      50 |    62.5 | 27,32-33
 ...ditor |      25 |        0 |       0 |      25 |
  ....tsx |      25 |        0 |       0 |      25 | 14-18
 ...ilder |       0 |        0 |       0 |       0 |
  ....tsx |       0 |        0 |       0 |       0 | 40-225
 ...Modal |     100 |      100 |     100 |     100 |
  ....tsx |     100 |      100 |     100 |     100 |
 ...debar |   95.83 |    53.84 |    87.5 |   95.83 |
  ....tsx |   95.83 |    53.84 |    87.5 |   95.83 | 49
 ...Input |   11.11 |        0 |       0 |    12.5 |
  ....tsx |   11.11 |        0 |       0 |    12.5 | 49-99
 ...tArea |     100 |    66.66 |     100 |     100 |
  ....tsx |     100 |    66.66 |     100 |     100 | 19,53-54
 ...ntext |     100 |    58.33 |     100 |     100 |
  ....tsx |     100 |    58.33 |     100 |     100 | 47-51
 ...rated |   43.75 |      100 |   18.18 |   43.75 |
  ...x.ts |   43.75 |      100 |   18.18 |   43.75 | ...42,28897-28904
 ...mocks |      60 |       50 |      60 |      60 |
  ...k.ts |      60 |       50 |      60 |      60 | 21-27
 ...s/msw |   85.71 |      100 |     100 |   85.71 |
  ...r.ts |       0 |      100 |     100 |       0 | 4
  ...s.ts |     100 |      100 |     100 |     100 |
  ...r.ts |     100 |      100 |     100 |     100 |
 .../next |       0 |        0 |       0 |       0 |
  ...t.ts |       0 |        0 |       0 |       0 | 5-14
  ...t.ts |       0 |        0 |       0 |       0 | 5-41
 ...types |   66.66 |        0 |       0 |   66.66 |
  ...x.ts |   66.66 |        0 |       0 |   66.66 | 79
  ...c.ts |       0 |        0 |       0 |       0 |
 ...utils |   18.32 |     13.2 |   18.33 |   18.62 |
  ....tsx |     100 |      100 |      80 |     100 |
  ...o.ts |      65 |    61.11 |   57.14 |   68.42 | 20-21,68,80-84
  ...e.ts |       0 |      100 |       0 |       0 | 2
  ...k.ts |       0 |      100 |       0 |       0 | 1-9
  ...t.ts |       0 |        0 |       0 |       0 | 14-49
  ...s.ts |     100 |      100 |     100 |     100 |
  ...t.ts |    6.25 |        0 |       0 |    6.66 | 29-64
  ...t.ts |       0 |        0 |       0 |       0 | 20-97
  ...e.ts |       0 |        0 |       0 |       0 | 3-25
  ...k.ts |   73.33 |    33.33 |     100 |   73.33 | 40-43,50
  ...p.ts |       0 |      100 |       0 |       0 | 6-7
  ...d.ts |       0 |      100 |       0 |       0 | 10-20
  ...e.ts |       0 |      100 |       0 |       0 | 1-3
  ...l.ts |      40 |        0 |       0 |      40 | 6-9
  ...a.ts |       0 |        0 |       0 |       0 | 5-41
  ...t.ts |       0 |      100 |       0 |       0 | 3-13
  ...h.ts |       0 |      100 |       0 |       0 | 5-17
  ...r.ts |       0 |        0 |       0 |       0 | 9-141
  ...x.ts |     100 |      100 |     100 |     100 |
  yup.ts  |       0 |        0 |       0 |       0 | 7-61
 .../auth |    4.08 |        0 |       0 |    4.34 |
  ...s.ts |       0 |        0 |       0 |       0 | 5-35
  auth.ts |       0 |        0 |       0 |       0 | 29-53
  ....tsx |    8.33 |        0 |       0 |    8.69 | 17-22,29-76
 ...ditor |       0 |        0 |       0 |       0 |
  ...s.ts |       0 |        0 |       0 |       0 | 4-58
 ...sions |       0 |        0 |       0 |       0 |
  ....tsx |       0 |      100 |       0 |       0 | 20-41
  ....tsx |       0 |        0 |       0 |       0 | 24-147
  ....tsx |       0 |        0 |       0 |       0 | 22-87
  ....tsx |       0 |      100 |       0 |       0 | 16-104
 ...utils |    5.88 |        0 |       0 |    5.88 |
  ...e.ts |    6.66 |        0 |       0 |    6.66 | 6-29
  ...t.ts |       0 |        0 |       0 |       0 | 3-15
 ...mmand |       0 |        0 |       0 |       0 |
  ....tsx |       0 |        0 |       0 |       0 | 19-131
  ....tsx |       0 |        0 |       0 |       0 | 23-204
  ....tsx |       0 |        0 |       0 |       0 | 15-152
 ...rrors |       0 |      100 |     100 |       0 |
  ....tsx |       0 |      100 |     100 |       0 | 1
 ...hooks |    1.57 |        0 |    2.43 |    1.09 |
  ....tsx |       0 |        0 |       0 |       0 | 20-75
  ....tsx |       0 |        0 |       0 |       0 | 11-27
  ....tsx |   28.57 |      100 |   16.66 |      25 | 15-20
  ....tsx |       0 |        0 |       0 |       0 | 8-38
  ....tsx |    7.14 |        0 |       0 |    7.14 | 7-37
  ....tsx |       0 |        0 |       0 |       0 | 55-273
  ....tsx |       0 |        0 |       0 |       0 | 12-139
 ...adata |    1.38 |        0 |       0 |    1.38 |
  load.ts |       0 |        0 |       0 |       0 | 8-160
  ...y.ts |      25 |      100 |       0 |      25 | 16-19
  ...s.ts |       0 |        0 |       0 |       0 |
 ...tests |     100 |      100 |       0 |     100 |
  ...s.ts |     100 |      100 |       0 |     100 |
----------|---------|----------|---------|---------|-------------------

Test Suites: 11 passed, 11 total
Tests:       17 passed, 17 total
Snapshots:   0 total
Time:        2.367 s, estimated 3 s
Ran all test suites.
pnpm run lint

> outstatic@1.0.4 lint /Users/knd/Code/personal/outstatic-1/packages/outstatic
> TIMING=1 eslint "src/**/*.ts*"


/Users/knd/Code/personal/outstatic-1/packages/outstatic/src/utils/editor/utils/slash-command/BaseCommandList.tsx
  72:5  warning  React Hook useCallback has a missing dependency: 'setImageMenu'. Either include it or remove the dependency array. If 'setImageMenu' changes too often, find the parent component that defines it and wrap that definition in useCallback  react-hooks/exhaustive-deps

/Users/knd/Code/personal/outstatic-1/packages/outstatic/src/utils/editor/utils/slash-command/ImageCommandList.tsx
  136:6  warning  React Hook useEffect has missing dependencies: 'addImageFile', 'addImageUrl', 'editor', and 'setImageMenu'. Either include them or remove the dependency array. If 'setImageMenu' changes too often, find the parent component that defines it and wrap that definition in useCallback  react-hooks/exhaustive-deps
  140:6  warning  React Hook useEffect has a missing dependency: 'editor'. Either include it or remove the dependency array                                                                                                                                                                               react-hooks/exhaustive-deps
  144:6  warning  React Hook useEffect has an unnecessary dependency: 'items'. Either exclude it or remove the dependency array. Outer scope values like 'items' aren't valid dependencies because mutating them doesn't re-render the component                                                          react-hooks/exhaustive-deps

/Users/knd/Code/personal/outstatic-1/packages/outstatic/src/utils/hooks/useTipTap.tsx
  87:6  warning  React Hook useEffect has a missing dependency: 'editor?.commands'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

✖ 5 problems (0 errors, 5 warnings)

Rule                              | Time (ms) | Relative
:---------------------------------|----------:|--------:
react/display-name                |    22.816 |    20.7%
react/no-direct-mutation-state    |    20.241 |    18.4%
react/require-render-return       |     8.876 |     8.1%
react-hooks/exhaustive-deps       |     8.389 |     7.6%
react/jsx-uses-react              |     7.071 |     6.4%
turbo/no-undeclared-env-vars      |     5.291 |     4.8%
react/no-deprecated               |     4.910 |     4.5%
jsx-a11y/role-supports-aria-props |     3.608 |     3.3%
react-hooks/rules-of-hooks        |     3.415 |     3.1%
react/no-danger-with-children     |     3.228 |     2.9%
```