### PR TITLE
fix: don't auto create links from 'https://'

### DIFF
--- a/.changeset/six-teachers-shake.md
+++ b/.changeset/six-teachers-shake.md
@@ -1,0 +1,5 @@
+---
+"outstatic": patch
+---
+
+fix: don't auto create links from 'https://'

--- a/packages/outstatic/src/utils/editor/extensions/index.tsx
+++ b/packages/outstatic/src/utils/editor/extensions/index.tsx
@@ -84,6 +84,7 @@ export const TiptapExtensions = [
   }),
   Markdown.configure({
     html: false,
+    linkify: false,
     transformPastedText: true
   }),
   Image.extend({


### PR DESCRIPTION
Linkify is breaking pages as it's invalid GFM