### PR TITLE
fix: Remove double border in aside

### DIFF
--- a/.changeset/spicy-apples-give.md
+++ b/.changeset/spicy-apples-give.md
@@ -1,0 +1,5 @@
+---
+"outstatic": patch
+---
+
+fix: Remove double border in aside

--- a/packages/outstatic/src/components/DocumentSettings/index.tsx
+++ b/packages/outstatic/src/components/DocumentSettings/index.tsx
@@ -133,7 +133,7 @@ const DocumentSettings = ({
       <aside
         className={`${
           isOpen ? 'block absolute' : 'hidden relative'
-        } md:block w-full border-b border-gray-300 bg-white md:w-64 md:flex-none md:flex-col md:flex-wrap md:items-start md:justify-start md:border-b-0 md:border-l py-6 h-full max-h-[calc(100vh-128px)] md:max-h-[calc(100vh-53px)] scrollbar-hide overflow-scroll`}
+        } md:block w-full border-b border-gray-300 bg-white md:w-64 md:flex-none md:flex-col md:flex-wrap md:items-start md:justify-start md:border-b-0 md:border-l pt-6 pb-16 h-full max-h-[calc(100vh-128px)] md:max-h-[calc(100vh-53px)] scrollbar-hide overflow-scroll`}
       >
         <div className="relative w-full items-center justify-between mb-4 flex px-4">
           <DateTimePicker
@@ -297,7 +297,6 @@ const DocumentSettings = ({
               )
             })}
         </div>
-        <hr className="pb-16" />
       </aside>
     </>
   )


### PR DESCRIPTION
Removed a double border in post aside:

**Before:**

https://github.com/avitorio/outstatic/assets/13696888/39126077-cfe6-4a79-95cb-501449449004


**After:**

https://github.com/avitorio/outstatic/assets/13696888/334cf9b1-ee1e-45a5-bef1-30301cc935cc

Not sure if this requires any tests or issues to be opened, if so let me know!

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
