### PR TITLE
chore: Move developer-related settings away from user-facing features

### DIFF
--- a/packages/outstatic/src/components/Sidebar/CollectionsList.tsx
+++ b/packages/outstatic/src/components/Sidebar/CollectionsList.tsx
@@ -5,7 +5,7 @@ import {
   SidebarGroup,
   SidebarItem
 } from '@/components/ui/outstatic/sidebar'
-import { Folder, LayoutDashboard, Plus } from 'lucide-react'
+import { Folder, Plus } from 'lucide-react'
 import {
   Tooltip,
   TooltipProvider,
@@ -20,66 +20,46 @@ const CollectionsList = () => {
   const { dashboardRoute } = useOutstatic()
 
   return (
-    <>
-      <SidebarContent>
-        <SidebarItem
-          path={dashboardRoute}
-          Icon={<LayoutDashboard className="w-4" />}
-        >
-          Dashboard
-        </SidebarItem>
-      </SidebarContent>
-
-      <div className="z-10">
-        <Link
-          href={`/outstatic/new`}
-          className="hidden group-hover:block bg-white p-1 border border-gray-200 text-gray-500 rounded-sm hover:text-gray-700"
-          aria-label='Create new item in collection "collection"'
-        >
-          <Plus strokeWidth={3} size={14} />
-        </Link>
-      </div>
-      <SidebarContent>
-        <SidebarGroup key="collections" label="Collections" collapsible={false}>
-          {collections
-            ? collections.map((collection) => (
-                <SidebarItem
-                  key={collection.slug}
-                  path={`${dashboardRoute}/${collection.slug}`}
-                  Icon={<Folder className="w-4" />}
-                  action={
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <div className="z-10 w-4">
-                            <Link
-                              href={`/outstatic/${collection.slug}/new`}
-                              className="hidden group-hover:block bg-white p-1 border border-gray-200 text-gray-500 rounded-sm hover:text-gray-700 w-6"
-                              aria-label='Create new item in collection "collection"'
-                            >
-                              <Plus strokeWidth={3} size={14} />
-                            </Link>
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>
-                            Create new{' '}
-                            <span className="inline-block">
-                              {singular(collection.title)}
-                            </span>
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  }
-                >
-                  {collection.title}
-                </SidebarItem>
-              ))
-            : null}
-        </SidebarGroup>
-      </SidebarContent>
-    </>
+    <SidebarContent>
+      <SidebarGroup key="collections" label="Collections" collapsible={false}>
+        {collections
+          ? collections.map((collection) => (
+              <SidebarItem
+                key={collection.slug}
+                path={`${dashboardRoute}/${collection.slug}`}
+                Icon={<Folder className="w-4" />}
+                action={
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div className="z-10 w-4">
+                          <Link
+                            href={`/outstatic/${collection.slug}/new`}
+                            className="hidden group-hover:block bg-white p-1 border border-gray-200 text-gray-500 rounded-sm hover:text-gray-700 w-6"
+                            aria-label='Create new item in collection "collection"'
+                          >
+                            <Plus strokeWidth={3} size={14} />
+                          </Link>
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>
+                          Create new{' '}
+                          <span className="inline-block">
+                            {singular(collection.title)}
+                          </span>
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                }
+              >
+                {collection.title}
+              </SidebarItem>
+            ))
+          : null}
+      </SidebarGroup>
+    </SidebarContent>
   )
 }
 

--- a/packages/outstatic/src/components/Sidebar/index.tsx
+++ b/packages/outstatic/src/components/Sidebar/index.tsx
@@ -1,14 +1,15 @@
-import useOutstatic from '@/utils/hooks/useOutstatic'
-import dynamic from 'next/dynamic'
-import { cn } from '@/utils/ui'
 import {
   SidebarContent,
   SidebarGroup,
   SidebarItem,
   Sidebar as SidebarUI
 } from '@/components/ui/outstatic/sidebar'
-import { Image, Settings } from 'lucide-react'
+import useOutstatic from '@/utils/hooks/useOutstatic'
+import { cn } from '@/utils/ui'
+import { Image, LayoutDashboard, Plus, Settings } from 'lucide-react'
+import dynamic from 'next/dynamic'
 import { SidebarFooter } from './sidebar-footer'
+import Link from 'next/link'
 
 const CollectionsList = dynamic(() => import('./CollectionsList'), {
   ssr: false
@@ -30,7 +31,7 @@ export const Sidebar = ({ isOpen = false }: SidebarProps) => {
       aria-label="Sidebar"
     >
       <SidebarUI className="flex flex-col justify-between">
-        <div className="mt-5">
+        <div>
           <CollectionsList />
           <SidebarContent>
             <SidebarGroup key="libraries" label="libraries" collapsible={false}>
@@ -42,8 +43,26 @@ export const Sidebar = ({ isOpen = false }: SidebarProps) => {
               </SidebarItem>
             </SidebarGroup>
           </SidebarContent>
+        </div>
+        <div className="flex-col">
+          <div className="z-10">
+            <Link
+              href={`/outstatic/new`}
+              className="hidden group-hover:block bg-white p-1 border border-gray-200 text-gray-500 rounded-sm hover:text-gray-700"
+              aria-label='Create new item in collection "collection"'
+            >
+              <Plus strokeWidth={3} size={14} />
+            </Link>
+          </div>
+
           <SidebarContent>
             <SidebarGroup key="settings" label="settings" collapsible={false}>
+              <SidebarItem
+                path={dashboardRoute}
+                Icon={<LayoutDashboard className="w-4" />}
+              >
+                Dashboard
+              </SidebarItem>
               <SidebarItem
                 path={`${dashboardRoute}/settings`}
                 Icon={<Settings className="w-4" />}
@@ -52,8 +71,8 @@ export const Sidebar = ({ isOpen = false }: SidebarProps) => {
               </SidebarItem>
             </SidebarGroup>
           </SidebarContent>
+          <SidebarFooter />
         </div>
-        <SidebarFooter />
       </SidebarUI>
     </div>
   )


### PR DESCRIPTION
## Feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Documentation added

¯\_(ツ)_/¯

Ok, so I was just playing with outstatic to see how hard it would be to contribute, take this PR with a pinch of salt. I'm faster coding than talking, so I did not create an RFC for that.

I finished creating a small website for my gf using a CMS. She is highly non-technical (types with one finger, does not understand anything about computer except opening chrome).

When I told the content of her website was ready to be updated via the CMS, I did not give her any indication on how to do it (good UX excercise). There was basically one collection called "Events". She was supposed to create a new Event, add some content, save, and profit.

What she ended up doing was creating a new collection (!), called with the name of the event she meant to create, then starting adding stuff to it assuming all would work.

Back to this PR: I thought it could be a good idea to separate the developer-facing stuff from the UI that is meant for content editors, avoiding this kind of things from happening. I believed the main issue was that the default page when loading outstatic was the list of collections.

This PR moves Settings + Collection list away from the rest of the content edition pages, to make them less prominent CTA (only the dev should go there, not users). Here's a screenshot of the result.

![Screenshot 2024-11-28 at 14 08 50](https://github.com/user-attachments/assets/c2481d24-8213-4cb8-bcd5-d038c5b4fc8b)

There are a couple of things that still need to be checked:

- [ ] The default homepage for users should probably not be the list of collections
- [ ] **Alternatively**: The dashboard should not show the collections, but stuff related to content, not structure, so the dashboard could stay up, but a new page should be created called "Collections Management" (or something), and placed next to settings.
- [ ] Test the empty state

WDYT of this change overall? If positive, we can work on addressing the points above.