### PR TITLE
Feat/fix singleton title updates

### DIFF
--- a/.changeset/fair-birds-clean.md
+++ b/.changeset/fair-birds-clean.md
@@ -1,0 +1,5 @@
+---
+'outstatic': patch
+---
+
+Fix singleton title and slug updates so the sidebar stays in sync after saving.

--- a/packages/outstatic/src/utils/hooks/use-submit-singleton.test.tsx
+++ b/packages/outstatic/src/utils/hooks/use-submit-singleton.test.tsx
@@ -9,7 +9,11 @@ import { useSingletons } from './use-singletons'
 import useOid from './use-oid'
 import matter from 'gray-matter'
 import { toast } from 'sonner'
-import useSubmitSingleton from './use-submit-singleton'
+import {
+  buildUpdatedSingletonsIndex,
+  stageSingletonRename,
+  default as useSubmitSingleton
+} from './use-submit-singleton'
 import { createCommitApi } from '@/utils/create-commit-api'
 import {
   addReferencedMedia,
@@ -85,6 +89,7 @@ const mockUseSingletons = useSingletons as jest.Mock
 const mockUseOid = useOid as jest.Mock
 const mockMatter = matter as jest.Mock
 const mockToastPromise = toast.promise as jest.Mock
+const mockToastError = toast.error as jest.Mock
 const mockCreateCommitApi = createCommitApi as jest.Mock
 const mockAddReferencedMedia = addReferencedMedia as jest.Mock
 const mockBuildMergedContent = buildMergedContent as jest.Mock
@@ -305,6 +310,321 @@ describe('useSubmitSingleton', () => {
     )
     expect(mutateAsyncMock).toHaveBeenCalledWith({ payload: 'commit-input' })
     expect(setSlugMock).toHaveBeenCalledWith('about-us')
+    expect(setHasChangesMock).toHaveBeenCalledWith(false)
     expect(refetchSingletonsMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('creates a new singleton and appends it to singletons.json', async () => {
+    const editor = {} as any
+
+    const { result } = renderHook(() =>
+      useSubmitSingleton({
+        session: {
+          user: {
+            login: 'acme'
+          }
+        } as any,
+        slug: 'new',
+        setSlug: setSlugMock,
+        isNew: true,
+        setIsNew: setIsNewMock,
+        setShowDelete: setShowDeleteMock,
+        setLoading: setLoadingMock,
+        files: [],
+        customFields: {},
+        setCustomFields: setCustomFieldsMock,
+        setHasChanges: setHasChangesMock,
+        editor,
+        extension: 'md',
+        documentMetadata: {}
+      })
+    )
+
+    await act(async () => {
+      await result.current({
+        title: 'Home Page',
+        slug: 'home-page',
+        status: 'published',
+        publishedAt: new Date('2026-02-01T00:00:00.000Z')
+      } as any)
+    })
+
+    expect(refetchSchemaMock).not.toHaveBeenCalled()
+    expect(replaceFileMock).toHaveBeenCalledWith(
+      'outstatic/content/_singletons/home-page.schema.json',
+      JSON.stringify(
+        {
+          title: 'Home Page',
+          type: 'object',
+          properties: {}
+        },
+        null,
+        2
+      ) + '\n'
+    )
+    expect(replaceFileMock).toHaveBeenCalledWith(
+      'outstatic/content/_singletons/home-page.md',
+      'content-body'
+    )
+    expect(replaceFileMock).toHaveBeenCalledWith(
+      'outstatic/content/singletons.json',
+      JSON.stringify(
+        [
+          {
+            title: 'About',
+            slug: 'about',
+            directory: 'outstatic/content/_singletons',
+            path: 'outstatic/content/_singletons/about.md',
+            publishedAt: '2026-01-01T00:00:00.000Z',
+            status: 'draft'
+          },
+          {
+            title: 'Home Page',
+            slug: 'home-page',
+            directory: 'outstatic/content/_singletons',
+            path: 'outstatic/content/_singletons/home-page.md',
+            publishedAt: '2026-02-01T00:00:00.000Z',
+            status: 'published'
+          }
+        ],
+        null,
+        2
+      ) + '\n'
+    )
+    expect(removeFileMock).not.toHaveBeenCalled()
+    expect(setSlugMock).toHaveBeenCalledWith('home-page')
+    expect(setHasChangesMock).toHaveBeenCalledWith(false)
+  })
+
+  it('does not remove existing files when saving without a slug change', async () => {
+    const editor = {} as any
+
+    const { result } = renderHook(() =>
+      useSubmitSingleton({
+        session: {
+          user: {
+            login: 'acme'
+          }
+        } as any,
+        slug: 'about',
+        setSlug: setSlugMock,
+        isNew: false,
+        setIsNew: setIsNewMock,
+        setShowDelete: setShowDeleteMock,
+        setLoading: setLoadingMock,
+        files: [],
+        customFields: {},
+        setCustomFields: setCustomFieldsMock,
+        setHasChanges: setHasChangesMock,
+        editor,
+        extension: 'md',
+        documentMetadata: {},
+        path: 'outstatic/content/_singletons'
+      })
+    )
+
+    await act(async () => {
+      await result.current({
+        title: 'About Us',
+        slug: 'about',
+        status: 'published',
+        publishedAt: new Date('2026-02-01T00:00:00.000Z')
+      } as any)
+    })
+
+    expect(removeFileMock).not.toHaveBeenCalled()
+    expect(setSlugMock).not.toHaveBeenCalled()
+    expect(setHasChangesMock).toHaveBeenCalledWith(false)
+  })
+
+  it('shows an error and exits early when the slug already exists', async () => {
+    const editor = {} as any
+    refetchSingletonsMock.mockResolvedValue({
+      data: [
+        {
+          title: 'About',
+          slug: 'about',
+          directory: 'outstatic/content/_singletons',
+          path: 'outstatic/content/_singletons/about.md',
+          publishedAt: '2026-01-01T00:00:00.000Z',
+          status: 'draft'
+        },
+        {
+          title: 'Contact',
+          slug: 'contact',
+          directory: 'outstatic/content/_singletons',
+          path: 'outstatic/content/_singletons/contact.md',
+          publishedAt: '2026-01-02T00:00:00.000Z',
+          status: 'published'
+        }
+      ]
+    })
+
+    const { result } = renderHook(() =>
+      useSubmitSingleton({
+        session: {
+          user: {
+            login: 'acme'
+          }
+        } as any,
+        slug: 'about',
+        setSlug: setSlugMock,
+        isNew: false,
+        setIsNew: setIsNewMock,
+        setShowDelete: setShowDeleteMock,
+        setLoading: setLoadingMock,
+        files: [],
+        customFields: {},
+        setCustomFields: setCustomFieldsMock,
+        setHasChanges: setHasChangesMock,
+        editor,
+        extension: 'md',
+        documentMetadata: {},
+        path: 'outstatic/content/_singletons'
+      })
+    )
+
+    await act(async () => {
+      await result.current({
+        title: 'Contact',
+        slug: 'contact',
+        status: 'published',
+        publishedAt: new Date('2026-02-01T00:00:00.000Z')
+      } as any)
+    })
+
+    expect(mockToastError).toHaveBeenCalledWith(
+      'A singleton with slug "contact" already exists.'
+    )
+    expect(refetchSchemaMock).not.toHaveBeenCalled()
+    expect(replaceFileMock).not.toHaveBeenCalled()
+    expect(mutateAsyncMock).not.toHaveBeenCalled()
+    expect(setLoadingMock).toHaveBeenNthCalledWith(1, true)
+    expect(setLoadingMock).toHaveBeenNthCalledWith(2, false)
+  })
+
+  it('resets loading and skips success side effects when commit creation fails', async () => {
+    const editor = {} as any
+    const error = new Error('commit failed')
+    mutateAsyncMock.mockRejectedValue(error)
+    const consoleSpy = jest
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined)
+
+    const { result } = renderHook(() =>
+      useSubmitSingleton({
+        session: {
+          user: {
+            login: 'acme'
+          }
+        } as any,
+        slug: 'about',
+        setSlug: setSlugMock,
+        isNew: false,
+        setIsNew: setIsNewMock,
+        setShowDelete: setShowDeleteMock,
+        setLoading: setLoadingMock,
+        files: [],
+        customFields: {},
+        setCustomFields: setCustomFieldsMock,
+        setHasChanges: setHasChangesMock,
+        editor,
+        extension: 'md',
+        documentMetadata: {},
+        path: 'outstatic/content/_singletons'
+      })
+    )
+
+    await act(async () => {
+      await result.current({
+        title: 'About Us',
+        slug: 'about-us',
+        status: 'published',
+        publishedAt: new Date('2026-02-01T00:00:00.000Z')
+      } as any)
+    })
+
+    expect(setLoadingMock).toHaveBeenCalledWith(false)
+    expect(setHasChangesMock).not.toHaveBeenCalled()
+    expect(setShowDeleteMock).not.toHaveBeenCalled()
+    expect(setIsNewMock).not.toHaveBeenCalled()
+    expect(consoleSpy).toHaveBeenCalledWith({ error })
+
+    consoleSpy.mockRestore()
+  })
+})
+
+describe('buildUpdatedSingletonsIndex', () => {
+  it('appends a new singleton entry when creating a singleton', () => {
+    expect(
+      buildUpdatedSingletonsIndex({
+        singletons: [
+          {
+            title: 'About',
+            slug: 'about',
+            directory: 'outstatic/content/_singletons',
+            path: 'outstatic/content/_singletons/about.md'
+          }
+        ],
+        isNew: true,
+        oldSlug: 'new',
+        nextEntry: {
+          title: 'Home',
+          slug: 'home',
+          directory: 'outstatic/content/_singletons',
+          path: 'outstatic/content/_singletons/home.md'
+        }
+      })
+    ).toEqual([
+      {
+        title: 'About',
+        slug: 'about',
+        directory: 'outstatic/content/_singletons',
+        path: 'outstatic/content/_singletons/about.md'
+      },
+      {
+        title: 'Home',
+        slug: 'home',
+        directory: 'outstatic/content/_singletons',
+        path: 'outstatic/content/_singletons/home.md'
+      }
+    ])
+  })
+})
+
+describe('stageSingletonRename', () => {
+  it('removes the existing content and schema when the slug changes', () => {
+    const capi = {
+      removeFile: jest.fn()
+    } as any
+
+    stageSingletonRename({
+      capi,
+      oldContentPath: 'outstatic/content/_singletons/about.md',
+      oldSchemaPath: 'outstatic/content/_singletons/about.schema.json',
+      didSlugChange: true
+    })
+
+    expect(capi.removeFile).toHaveBeenCalledWith(
+      'outstatic/content/_singletons/about.md'
+    )
+    expect(capi.removeFile).toHaveBeenCalledWith(
+      'outstatic/content/_singletons/about.schema.json'
+    )
+  })
+
+  it('does nothing when the slug stays the same', () => {
+    const capi = {
+      removeFile: jest.fn()
+    } as any
+
+    stageSingletonRename({
+      capi,
+      oldContentPath: 'outstatic/content/_singletons/about.md',
+      oldSchemaPath: 'outstatic/content/_singletons/about.schema.json',
+      didSlugChange: false
+    })
+
+    expect(capi.removeFile).not.toHaveBeenCalled()
   })
 })

--- a/packages/outstatic/src/utils/hooks/use-submit-singleton.test.tsx
+++ b/packages/outstatic/src/utils/hooks/use-submit-singleton.test.tsx
@@ -1,0 +1,310 @@
+import { act, renderHook } from '@testing-library/react'
+import { useOutstatic } from '@/utils/hooks/use-outstatic'
+import { useCreateCommit } from './use-create-commit'
+import { useGetConfig } from './use-get-config'
+import { useGetMediaFiles } from './use-get-media-files'
+import { useGetMetadata } from './use-get-metadata'
+import { useGetSingletonSchema } from './use-get-singleton-schema'
+import { useSingletons } from './use-singletons'
+import useOid from './use-oid'
+import matter from 'gray-matter'
+import { toast } from 'sonner'
+import useSubmitSingleton from './use-submit-singleton'
+import { createCommitApi } from '@/utils/create-commit-api'
+import {
+  addReferencedMedia,
+  buildMergedContent,
+  createMetadataState,
+  replaceConfigFile,
+  replaceMediaFile,
+  syncCustomFieldTags
+} from './use-submit-entry-shared'
+
+jest.mock('@/utils/hooks/use-outstatic', () => ({
+  useOutstatic: jest.fn()
+}))
+
+jest.mock('./use-create-commit', () => ({
+  useCreateCommit: jest.fn()
+}))
+
+jest.mock('./use-get-config', () => ({
+  useGetConfig: jest.fn()
+}))
+
+jest.mock('./use-get-media-files', () => ({
+  useGetMediaFiles: jest.fn()
+}))
+
+jest.mock('./use-get-metadata', () => ({
+  useGetMetadata: jest.fn()
+}))
+
+jest.mock('./use-get-singleton-schema', () => ({
+  useGetSingletonSchema: jest.fn()
+}))
+
+jest.mock('./use-singletons', () => ({
+  useSingletons: jest.fn()
+}))
+
+jest.mock('./use-oid', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+jest.mock('@/utils/create-commit-api', () => ({
+  createCommitApi: jest.fn()
+}))
+
+jest.mock('./use-submit-entry-shared', () => ({
+  addReferencedMedia: jest.fn(),
+  buildMergedContent: jest.fn(),
+  createMetadataState: jest.fn(),
+  replaceConfigFile: jest.fn(),
+  replaceMediaFile: jest.fn(),
+  syncCustomFieldTags: jest.fn()
+}))
+
+jest.mock('gray-matter', () => jest.fn())
+
+jest.mock('sonner', () => ({
+  toast: {
+    promise: jest.fn(),
+    error: jest.fn()
+  }
+}))
+
+const mockUseOutstatic = useOutstatic as jest.Mock
+const mockUseCreateCommit = useCreateCommit as jest.Mock
+const mockUseGetConfig = useGetConfig as jest.Mock
+const mockUseGetMediaFiles = useGetMediaFiles as jest.Mock
+const mockUseGetMetadata = useGetMetadata as jest.Mock
+const mockUseGetSingletonSchema = useGetSingletonSchema as jest.Mock
+const mockUseSingletons = useSingletons as jest.Mock
+const mockUseOid = useOid as jest.Mock
+const mockMatter = matter as jest.Mock
+const mockToastPromise = toast.promise as jest.Mock
+const mockCreateCommitApi = createCommitApi as jest.Mock
+const mockAddReferencedMedia = addReferencedMedia as jest.Mock
+const mockBuildMergedContent = buildMergedContent as jest.Mock
+const mockCreateMetadataState = createMetadataState as jest.Mock
+const mockReplaceConfigFile = replaceConfigFile as jest.Mock
+const mockReplaceMediaFile = replaceMediaFile as jest.Mock
+const mockSyncCustomFieldTags = syncCustomFieldTags as jest.Mock
+
+describe('useSubmitSingleton', () => {
+  const mutateAsyncMock = jest.fn()
+  const fetchOidMock = jest.fn()
+  const refetchSchemaMock = jest.fn()
+  const refetchMetadataMock = jest.fn()
+  const refetchMediaMock = jest.fn()
+  const refetchConfigMock = jest.fn()
+  const refetchSingletonsMock = jest.fn()
+  const replaceFileMock = jest.fn()
+  const removeFileMock = jest.fn()
+  const createInputMock = jest.fn()
+  const setSlugMock = jest.fn()
+  const setIsNewMock = jest.fn()
+  const setShowDeleteMock = jest.fn()
+  const setLoadingMock = jest.fn()
+  const setCustomFieldsMock = jest.fn()
+  const setHasChangesMock = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockUseOutstatic.mockReturnValue({
+      repoOwner: 'acme',
+      repoSlug: 'site',
+      repoBranch: 'main',
+      monorepoPath: '',
+      ostContent: 'outstatic/content',
+      basePath: '',
+      publicMediaPath: 'public/images',
+      repoMediaPath: 'outstatic/public/images',
+      mediaJsonPath: 'outstatic/content/media.json',
+      configJsonPath: 'outstatic/content/config.json'
+    })
+
+    mockUseCreateCommit.mockReturnValue({
+      mutateAsync: mutateAsyncMock
+    })
+    mockUseGetConfig.mockReturnValue({
+      refetch: refetchConfigMock
+    })
+    mockUseGetMediaFiles.mockReturnValue({
+      refetch: refetchMediaMock
+    })
+    mockUseGetMetadata.mockReturnValue({
+      refetch: refetchMetadataMock
+    })
+    mockUseGetSingletonSchema.mockReturnValue({
+      refetch: refetchSchemaMock
+    })
+    mockUseSingletons.mockReturnValue({
+      refetch: refetchSingletonsMock
+    })
+    mockUseOid.mockReturnValue(fetchOidMock)
+    mockCreateCommitApi.mockReturnValue({
+      replaceFile: replaceFileMock,
+      removeFile: removeFileMock,
+      createInput: createInputMock
+    })
+
+    mockBuildMergedContent.mockReturnValue('content-body')
+    mockAddReferencedMedia.mockReturnValue({
+      content: 'content-body',
+      media: []
+    })
+    mockMatter.mockReturnValue({
+      data: {
+        title: 'About Us',
+        status: 'published'
+      }
+    })
+    mockSyncCustomFieldTags.mockReturnValue({
+      customFields: {},
+      hasNewTag: false
+    })
+    mockCreateMetadataState.mockReturnValue({
+      metadata: [
+        {
+          collection: '_singletons',
+          slug: 'about'
+        },
+        {
+          collection: 'posts',
+          slug: 'hello-world'
+        }
+      ],
+      commit: 'commit-123'
+    })
+    mockReplaceMediaFile.mockResolvedValue(undefined)
+    mockReplaceConfigFile.mockResolvedValue(undefined)
+    fetchOidMock.mockResolvedValue('oid-123')
+    refetchSchemaMock.mockResolvedValue({
+      data: {
+        title: 'About',
+        type: 'object',
+        properties: {}
+      },
+      isError: false
+    })
+    refetchMetadataMock.mockResolvedValue({
+      data: {
+        metadata: [],
+        commitUrl: 'https://github.com/acme/site/commit/123'
+      },
+      isError: false
+    })
+    refetchSingletonsMock.mockResolvedValue({
+      data: [
+        {
+          title: 'About',
+          slug: 'about',
+          directory: 'outstatic/content/_singletons',
+          path: 'outstatic/content/_singletons/about.md',
+          publishedAt: '2026-01-01T00:00:00.000Z',
+          status: 'draft'
+        }
+      ]
+    })
+    createInputMock.mockReturnValue({ payload: 'commit-input' })
+    mutateAsyncMock.mockResolvedValue({})
+    mockToastPromise.mockImplementation(
+      async (
+        promise: Promise<unknown>,
+        handlers?: {
+          success?: (() => string) | string
+        }
+      ) => {
+        const result = await promise
+        if (typeof handlers?.success === 'function') {
+          handlers.success()
+        }
+        return result
+      }
+    )
+  })
+
+  it('updates singletons.json and renames files when an existing singleton changes slug', async () => {
+    const editor = {} as any
+
+    const { result } = renderHook(() =>
+      useSubmitSingleton({
+        session: {
+          user: {
+            login: 'acme'
+          }
+        } as any,
+        slug: 'about',
+        setSlug: setSlugMock,
+        isNew: false,
+        setIsNew: setIsNewMock,
+        setShowDelete: setShowDeleteMock,
+        setLoading: setLoadingMock,
+        files: [],
+        customFields: {},
+        setCustomFields: setCustomFieldsMock,
+        setHasChanges: setHasChangesMock,
+        editor,
+        extension: 'md',
+        documentMetadata: {},
+        path: 'outstatic/content/_singletons'
+      })
+    )
+
+    await act(async () => {
+      await result.current({
+        title: 'About Us',
+        slug: 'about-us',
+        status: 'published',
+        publishedAt: new Date('2026-02-01T00:00:00.000Z')
+      } as any)
+    })
+
+    expect(removeFileMock).toHaveBeenCalledWith(
+      'outstatic/content/_singletons/about.md'
+    )
+    expect(removeFileMock).toHaveBeenCalledWith(
+      'outstatic/content/_singletons/about.schema.json'
+    )
+    expect(replaceFileMock).toHaveBeenCalledWith(
+      'outstatic/content/_singletons/about-us.md',
+      'content-body'
+    )
+    expect(replaceFileMock).toHaveBeenCalledWith(
+      'outstatic/content/_singletons/about-us.schema.json',
+      JSON.stringify(
+        {
+          title: 'About',
+          type: 'object',
+          properties: {}
+        },
+        null,
+        2
+      ) + '\n'
+    )
+    expect(replaceFileMock).toHaveBeenCalledWith(
+      'outstatic/content/singletons.json',
+      JSON.stringify(
+        [
+          {
+            title: 'About Us',
+            slug: 'about-us',
+            directory: 'outstatic/content/_singletons',
+            path: 'outstatic/content/_singletons/about-us.md',
+            publishedAt: '2026-02-01T00:00:00.000Z',
+            status: 'published'
+          }
+        ],
+        null,
+        2
+      ) + '\n'
+    )
+    expect(mutateAsyncMock).toHaveBeenCalledWith({ payload: 'commit-input' })
+    expect(setSlugMock).toHaveBeenCalledWith('about-us')
+    expect(refetchSingletonsMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/outstatic/src/utils/hooks/use-submit-singleton.ts
+++ b/packages/outstatic/src/utils/hooks/use-submit-singleton.ts
@@ -26,6 +26,15 @@ import {
   syncCustomFieldTags
 } from './use-submit-entry-shared'
 
+type SingletonIndexEntry = {
+  title: string
+  slug: string
+  directory: string
+  path: string
+  publishedAt?: string
+  status?: string
+}
+
 type SubmitSingletonProps = {
   session: LoginSession | null
   slug: string
@@ -47,6 +56,97 @@ type SubmitSingletonProps = {
 
 type OnSubmitOptions = {
   configUpdate?: Partial<ConfigType>
+}
+
+type ResolveSingletonPathsArgs = {
+  oldSlug: string
+  nextSlug: string
+  extension: MDExtensions
+  singletonsPath: string
+  path?: string
+  existingFilePath?: string
+}
+
+type SingletonPaths = {
+  oldContentPath: string
+  newContentPath: string
+  contentDirectory: string
+  oldSchemaPath: string
+  newSchemaPath: string
+}
+
+type BuildUpdatedSingletonsIndexArgs = {
+  singletons: SingletonIndexEntry[]
+  isNew: boolean
+  oldSlug: string
+  nextEntry: SingletonIndexEntry
+}
+
+const resolveSingletonPaths = ({
+  oldSlug,
+  nextSlug,
+  extension,
+  singletonsPath,
+  path,
+  existingFilePath
+}: ResolveSingletonPathsArgs): SingletonPaths => {
+  const hasCustomPath = path !== undefined
+  const oldContentPath = existingFilePath
+    ? existingFilePath
+    : hasCustomPath
+      ? `${path ? `${path}/` : ''}${oldSlug}.${extension}`
+      : `${singletonsPath}/${oldSlug}.${extension}`
+
+  const contentDirectory = oldContentPath.includes('/')
+    ? oldContentPath.substring(0, oldContentPath.lastIndexOf('/'))
+    : ''
+
+  const newContentPath =
+    contentDirectory.length > 0
+      ? `${contentDirectory}/${nextSlug}.${extension}`
+      : `${nextSlug}.${extension}`
+
+  return {
+    oldContentPath,
+    newContentPath,
+    contentDirectory,
+    oldSchemaPath: `${singletonsPath}/${oldSlug}.schema.json`,
+    newSchemaPath: `${singletonsPath}/${nextSlug}.schema.json`
+  }
+}
+
+const buildUpdatedSingletonsIndex = ({
+  singletons,
+  isNew,
+  oldSlug,
+  nextEntry
+}: BuildUpdatedSingletonsIndexArgs) => {
+  if (isNew) {
+    return [...singletons, nextEntry]
+  }
+
+  return singletons.map((singleton) =>
+    singleton.slug === oldSlug ? nextEntry : singleton
+  )
+}
+
+const stageSingletonRename = ({
+  capi,
+  oldContentPath,
+  oldSchemaPath,
+  didSlugChange
+}: {
+  capi: ReturnType<typeof createCommitApi>
+  oldContentPath: string
+  oldSchemaPath: string
+  didSlugChange: boolean
+}) => {
+  if (!didSlugChange) {
+    return
+  }
+
+  capi.removeFile(oldContentPath)
+  capi.removeFile(oldSchemaPath)
 }
 
 function useSubmitSingleton({
@@ -103,17 +203,26 @@ function useSubmitSingleton({
       }
 
       try {
-        let actualSlug = slug
-        if (isNew) {
-          const title = data.title || 'untitled'
-          actualSlug = slugify(title, { allowedChars: 'a-zA-Z0-9.' })
+        const title = data.title || 'untitled'
+        const nextSlug =
+          data.slug?.trim() ||
+          slugify(title, { allowedChars: 'a-zA-Z0-9.' }) ||
+          slug
+        const oldSlug = slug
+        const didSlugChange = !isNew && nextSlug !== oldSlug
 
-          const { data: singletons } = await refetchSingletons()
-          if (singletons?.find((singleton) => singleton.slug === actualSlug)) {
-            toast.error(`A singleton with slug "${actualSlug}" already exists.`)
-            setLoading(false)
-            return
-          }
+        const { data: currentSingletons } = await refetchSingletons()
+        const singletons = currentSingletons ?? []
+
+        if (
+          singletons.find(
+            (singleton) =>
+              singleton.slug === nextSlug && singleton.slug !== oldSlug
+          )
+        ) {
+          toast.error(`A singleton with slug "${nextSlug}" already exists.`)
+          setLoading(false)
+          return
         }
 
         const [
@@ -146,51 +255,38 @@ function useSubmitSingleton({
 
         const capi = createCommitApi({
           message: isNew
-            ? `feat(singleton): create ${actualSlug}`
-            : `chore: Updates singleton ${actualSlug}`,
+            ? `feat(singleton): create ${nextSlug}`
+            : `chore: Updates singleton ${nextSlug}`,
           owner,
           oid: oid ?? '',
           name: repoSlug,
           branch: repoBranch
         })
 
-        const hasCustomPath = path !== undefined
-        const contentFilePath = existingFilePath
-          ? existingFilePath
-          : hasCustomPath
-            ? `${path ? `${path}/` : ''}${actualSlug}.${extension}`
-            : `${singletonsPath}/${actualSlug}.${extension}`
-
-        const contentDirectory = existingFilePath
-          ? existingFilePath.substring(0, existingFilePath.lastIndexOf('/'))
-          : hasCustomPath
-            ? path || ''
-            : singletonsPath
+        const {
+          oldContentPath,
+          newContentPath,
+          contentDirectory,
+          oldSchemaPath,
+          newSchemaPath
+        } = resolveSingletonPaths({
+          oldSlug,
+          nextSlug,
+          extension,
+          singletonsPath,
+          path,
+          existingFilePath
+        })
 
         if (isNew) {
           const schemaJson = {
-            title: data.title || actualSlug,
+            title: data.title || nextSlug,
             type: 'object',
             properties: {}
           }
           capi.replaceFile(
-            `${singletonsPath}/${actualSlug}.schema.json`,
+            newSchemaPath,
             JSON.stringify(schemaJson, null, 2) + '\n'
-          )
-
-          const { data: currentSingletons } = await refetchSingletons()
-          const singletonsArray = currentSingletons ?? []
-          singletonsArray.push({
-            title: data.title || actualSlug,
-            slug: actualSlug,
-            directory: contentDirectory,
-            path: contentFilePath,
-            publishedAt: data.publishedAt?.toISOString(),
-            status: data.status
-          })
-          capi.replaceFile(
-            `${ostContent}/singletons.json`,
-            JSON.stringify(singletonsArray, null, 2) + '\n'
           )
         }
 
@@ -205,7 +301,7 @@ function useSubmitSingleton({
 
         const { data: matterData } = matter(content)
 
-        capi.replaceFile(contentFilePath, content)
+        capi.replaceFile(newContentPath, content)
 
         const { customFields: nextCustomFields, hasNewTag } =
           syncCustomFieldTags({
@@ -215,21 +311,48 @@ function useSubmitSingleton({
             setCustomFields
           })
 
-        if (hasNewTag && !isNew) {
-          const customFieldsJSON = JSON.stringify(
-            {
-              ...schema,
-              properties: { ...nextCustomFields }
-            },
-            null,
-            2
-          )
+        const nextSchema =
+          hasNewTag && !isNew
+            ? {
+                ...schema,
+                properties: { ...nextCustomFields }
+              }
+            : schema
 
+        if (!isNew && nextSchema && (hasNewTag || didSlugChange)) {
           capi.replaceFile(
-            `${singletonsPath}/${actualSlug}.schema.json`,
-            customFieldsJSON + '\n'
+            newSchemaPath,
+            JSON.stringify(nextSchema, null, 2) + '\n'
           )
         }
+
+        stageSingletonRename({
+          capi,
+          oldContentPath,
+          oldSchemaPath,
+          didSlugChange
+        })
+
+        const nextSingletonEntry: SingletonIndexEntry = {
+          title: data.title || nextSlug,
+          slug: nextSlug,
+          directory: contentDirectory || singletonsPath,
+          path: newContentPath,
+          publishedAt: data.publishedAt?.toISOString(),
+          status: data.status
+        }
+
+        const updatedSingletons = buildUpdatedSingletonsIndex({
+          singletons,
+          isNew,
+          oldSlug,
+          nextEntry: nextSingletonEntry
+        })
+
+        capi.replaceFile(
+          `${ostContent}/singletons.json`,
+          JSON.stringify(updatedSingletons, null, 2) + '\n'
+        )
 
         const metadataState = createMetadataState(metadata)
         const state = MurmurHash3(content)
@@ -237,20 +360,21 @@ function useSubmitSingleton({
         const newMeta = Array.isArray(metadataState.metadata)
           ? metadataState.metadata.filter(
               (entry) =>
-                entry.collection !== '_singletons' || entry.slug !== actualSlug
+                entry.collection !== '_singletons' ||
+                (entry.slug !== oldSlug && entry.slug !== nextSlug)
             )
           : []
 
         newMeta.push({
           ...matterData,
-          slug: actualSlug,
+          slug: nextSlug,
           collection: '_singletons',
           __outstatic: {
             hash: `${state.result()}`,
             commit: metadataState.commit,
             path: monorepoPath
-              ? contentFilePath.replace(monorepoPath, '')
-              : contentFilePath
+              ? newContentPath.replace(monorepoPath, '')
+              : newContentPath
           }
         })
 
@@ -279,10 +403,10 @@ function useSubmitSingleton({
         toast.promise(createCommit.mutateAsync(input), {
           loading: isNew ? 'Creating singleton...' : 'Saving changes...',
           success: () => {
-            if (isNew) {
-              setSlug(actualSlug)
-              refetchSingletons()
+            if (isNew || didSlugChange) {
+              setSlug(nextSlug)
             }
+            refetchSingletons()
             return isNew
               ? 'Singleton created successfully!'
               : 'Changes saved successfully!'

--- a/packages/outstatic/src/utils/hooks/use-submit-singleton.ts
+++ b/packages/outstatic/src/utils/hooks/use-submit-singleton.ts
@@ -115,7 +115,7 @@ const resolveSingletonPaths = ({
   }
 }
 
-const buildUpdatedSingletonsIndex = ({
+export const buildUpdatedSingletonsIndex = ({
   singletons,
   isNew,
   oldSlug,
@@ -130,7 +130,7 @@ const buildUpdatedSingletonsIndex = ({
   )
 }
 
-const stageSingletonRename = ({
+export const stageSingletonRename = ({
   capi,
   oldContentPath,
   oldSchemaPath,
@@ -336,6 +336,9 @@ function useSubmitSingleton({
         const nextSingletonEntry: SingletonIndexEntry = {
           title: data.title || nextSlug,
           slug: nextSlug,
+          // Keep the stored directory anchored to the content location. When a
+          // singleton resolves to a root-level file, fall back to the standard
+          // singletons directory instead of persisting an empty directory string.
           directory: contentDirectory || singletonsPath,
           path: newContentPath,
           publishedAt: data.publishedAt?.toISOString(),
@@ -400,7 +403,7 @@ function useSubmitSingleton({
 
         const input = capi.createInput()
 
-        toast.promise(createCommit.mutateAsync(input), {
+        await toast.promise(createCommit.mutateAsync(input), {
           loading: isNew ? 'Creating singleton...' : 'Saving changes...',
           success: () => {
             if (isNew || didSlugChange) {


### PR DESCRIPTION
## Summary
- Refactor the singleton submit hook to follow the same linear save pattern as document saves
- Extract singleton path resolution, rename staging, and index updates into small helpers
- Keep the singleton sidebar index and rename behavior working for title and slug edits

## Testing
- `pnpm test -- packages/outstatic/src/utils/hooks/use-submit-singleton.test.tsx`