### PR TITLE
Keep cached collections and singletons visible when GitHub metadata f…

### DIFF
--- a/.changeset/quiet-metadata-auth-errors.md
+++ b/.changeset/quiet-metadata-auth-errors.md
@@ -1,0 +1,5 @@
+---
+'outstatic': patch
+---
+
+Keep cached collections and singletons visible when GitHub metadata fetches hit a temporary bad credentials error.

--- a/packages/outstatic/src/utils/errors/is-github-credentials-error.ts
+++ b/packages/outstatic/src/utils/errors/is-github-credentials-error.ts
@@ -1,0 +1,24 @@
+type ErrorWithResponse = {
+  response?: {
+    status?: number
+    message?: unknown
+  }
+}
+
+export function isGithubCredentialsError(
+  error: unknown
+): error is ErrorWithResponse {
+  const response =
+    typeof error === 'object' && error !== null && 'response' in error
+      ? (error as ErrorWithResponse).response
+      : undefined
+
+  const status = response?.status
+  const message = response?.message
+
+  return (
+    (status === 401 || status === 403) &&
+    typeof message === 'string' &&
+    message.includes('credentials')
+  )
+}

--- a/packages/outstatic/src/utils/hooks/use-collections.test.tsx
+++ b/packages/outstatic/src/utils/hooks/use-collections.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { useOutstatic } from '@/utils/hooks/use-outstatic'
 import useOid from './use-oid'
 import { useCreateCommit } from './use-create-commit'
@@ -42,6 +42,7 @@ const mockUseOid = useOid as jest.Mock
 const mockUseCreateCommit = useCreateCommit as jest.Mock
 const mockCreateCommitApi = createCommitApi as jest.Mock
 const mockToastPromise = toast.promise as jest.Mock
+const mockToastError = toast.error as jest.Mock
 
 const requestMock = jest.fn()
 const fetchOidMock = jest.fn()
@@ -187,5 +188,46 @@ describe('useCollections', () => {
       JSON.stringify(expectedCollections, null, 2)
     )
     expect(mutateAsyncMock).toHaveBeenCalledWith({ payload: 'commit-input' })
+  })
+
+  it('keeps existing collections and skips toast when collections.json refetch gets bad credentials', async () => {
+    const existingCollections = [
+      {
+        title: 'Posts',
+        slug: 'posts',
+        path: 'outstatic/content/posts',
+        children: []
+      }
+    ]
+
+    requestMock
+      .mockResolvedValueOnce({
+        repository: {
+          object: {
+            text: JSON.stringify(existingCollections)
+          }
+        }
+      })
+      .mockRejectedValueOnce({
+        response: {
+          status: 401,
+          message: 'Bad credentials'
+        }
+      })
+
+    const { result } = renderHook(() => useCollections(), {
+      wrapper: createWrapper()
+    })
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(existingCollections)
+    })
+
+    await act(async () => {
+      await result.current.refetch()
+    })
+
+    expect(result.current.data).toEqual(existingCollections)
+    expect(mockToastError).not.toHaveBeenCalled()
   })
 })

--- a/packages/outstatic/src/utils/hooks/use-collections.ts
+++ b/packages/outstatic/src/utils/hooks/use-collections.ts
@@ -8,6 +8,7 @@ import { useCreateCommit } from './use-create-commit'
 import { GET_FILE } from '@/graphql/queries/file'
 import { sentenceCase } from 'change-case'
 import { stringifyError } from '@/utils/errors/stringify-error'
+import { isGithubCredentialsError } from '@/utils/errors/is-github-credentials-error'
 
 export type CollectionType = {
   title: string
@@ -137,6 +138,10 @@ export function useCollections(options?: UseCollectionsOptions) {
         }
         return []
       } catch (error) {
+        if (isGithubCredentialsError(error)) {
+          throw error
+        }
+
         console.error('Error fetching collections:', error)
         const errorToast = toast.error('Error fetching collections', {
           action: {

--- a/packages/outstatic/src/utils/hooks/use-singletons.test.tsx
+++ b/packages/outstatic/src/utils/hooks/use-singletons.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { useOutstatic } from '@/utils/hooks/use-outstatic'
 import useOid from './use-oid'
 import { useCreateCommit } from './use-create-commit'
@@ -42,6 +42,7 @@ const mockUseCreateCommit = useCreateCommit as jest.Mock
 const mockUseGetDocuments = useGetDocuments as jest.Mock
 const mockCreateCommitApi = createCommitApi as jest.Mock
 const mockToastPromise = toast.promise as jest.Mock
+const mockToastError = toast.error as jest.Mock
 
 const requestMock = jest.fn()
 const fetchOidMock = jest.fn()
@@ -202,5 +203,48 @@ describe('useSingletons', () => {
     expect(createInputMock).toHaveBeenCalledTimes(1)
     expect(mutateAsyncMock).toHaveBeenCalledWith({ payload: 'commit-input' })
     expect(mockToastPromise).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps existing singletons and skips toast when singletons.json refetch gets bad credentials', async () => {
+    const existingSingletons = [
+      {
+        title: 'About',
+        slug: 'about',
+        path: 'outstatic/content/_singletons/about.mdx',
+        directory: 'outstatic/content/_singletons',
+        publishedAt: '2026-01-01',
+        status: 'published'
+      }
+    ]
+
+    requestMock
+      .mockResolvedValueOnce({
+        repository: {
+          object: {
+            text: JSON.stringify(existingSingletons)
+          }
+        }
+      })
+      .mockRejectedValueOnce({
+        response: {
+          status: 401,
+          message: 'Bad credentials'
+        }
+      })
+
+    const { result } = renderHook(() => useSingletons(), {
+      wrapper: createWrapper()
+    })
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(existingSingletons)
+    })
+
+    await act(async () => {
+      await result.current.refetch()
+    })
+
+    expect(result.current.data).toEqual(existingSingletons)
+    expect(mockToastError).not.toHaveBeenCalled()
   })
 })

--- a/packages/outstatic/src/utils/hooks/use-singletons.ts
+++ b/packages/outstatic/src/utils/hooks/use-singletons.ts
@@ -7,6 +7,7 @@ import { useCreateCommit } from './use-create-commit'
 import { GET_FILE } from '@/graphql/queries/file'
 import { useGetDocuments } from './use-get-documents'
 import { SingletonsType } from '@/types/singleton'
+import { isGithubCredentialsError } from '@/utils/errors/is-github-credentials-error'
 
 type UseGetSingletonsOptions = {
   enabled?: boolean
@@ -105,6 +106,10 @@ export function useSingletons(options?: UseGetSingletonsOptions) {
         }
         return []
       } catch (error) {
+        if (isGithubCredentialsError(error)) {
+          throw error
+        }
+
         console.error('Error fetching singletons:', error)
         toast.error('Error fetching singletons')
         return []

--- a/packages/outstatic/src/utils/react-query/query-client.ts
+++ b/packages/outstatic/src/utils/react-query/query-client.ts
@@ -9,6 +9,7 @@ import { compress, decompress } from 'lz-string'
 import { toast } from 'sonner'
 import { ClientError } from 'graphql-request'
 import { stringifyError } from '@/utils/errors/stringify-error'
+import { isGithubCredentialsError } from '@/utils/errors/is-github-credentials-error'
 
 // Create a client
 export const queryClient = new QueryClient({
@@ -21,14 +22,7 @@ export const queryClient = new QueryClient({
         // serves as a fallback for non-GraphQL errors or cases where the
         // interceptor fails to refresh the token.
         if (error instanceof ClientError) {
-          const status = error.response?.status
-          const message = error.response?.message
-          const isAuthError =
-            (status === 401 || status === 403) &&
-            typeof message === 'string' &&
-            message.includes('credentials')
-
-          if (isAuthError) {
+          if (isGithubCredentialsError(error)) {
             // Silently handle auth errors - don't show toast or log
             // GraphQL interceptor handles refresh attempts, and if it fails,
             // the user should be redirected to login (handled elsewhere)


### PR DESCRIPTION
## Summary
- Preserve the last successful collections and singletons data when GitHub metadata fetches fail with bad credentials.
- Skip toast noise for these auth failures so transient token issues do not surface as user-facing errors.
- Add a shared GitHub credentials error helper and cover the behavior with regression tests.

## Testing
- Added unit tests for collections and singletons refetch failures to confirm cached data remains visible.
- Formatting passed.
- Targeted Jest tests for the updated hooks passed.
- Lint passed with existing unrelated warnings in other packages.