### PR TITLE
Fix/dialog hydration error

### DIFF
--- a/.changeset/fix-upgrade-dialog-hydration.md
+++ b/.changeset/fix-upgrade-dialog-hydration.md
@@ -1,0 +1,5 @@
+---
+'outstatic': patch
+---
+
+Fix hydration mismatches from the Pro upgrade dialog trigger.

--- a/.changeset/fix-upgrade-dialog-hydration.md
+++ b/.changeset/fix-upgrade-dialog-hydration.md
@@ -2,4 +2,4 @@
 'outstatic': patch
 ---
 
-Fix hydration mismatches from the Pro upgrade dialog trigger.
+Fix hydration mismatches from the PRO upgrade dialog trigger.

--- a/packages/outstatic/src/components/ui/outstatic/__tests__/upgrade-dialog.test.tsx
+++ b/packages/outstatic/src/components/ui/outstatic/__tests__/upgrade-dialog.test.tsx
@@ -1,0 +1,18 @@
+import { UpgradeDialog } from '../upgrade-dialog'
+
+const { renderToString } =
+  require('react-dom/server.node') as typeof import('react-dom/server')
+
+describe('UpgradeDialog', () => {
+  it('server-renders trigger children without mounting Radix dialog markup', () => {
+    const html = renderToString(
+      <UpgradeDialog>
+        <button type="button">Upgrade</button>
+      </UpgradeDialog>
+    )
+
+    expect(html).toContain('Upgrade')
+    expect(html).not.toContain('radix-')
+    expect(html).not.toContain('Upgrade to Pro')
+  })
+})

--- a/packages/outstatic/src/components/ui/outstatic/upgrade-dialog.tsx
+++ b/packages/outstatic/src/components/ui/outstatic/upgrade-dialog.tsx
@@ -76,10 +76,19 @@ export function UpgradeDialog({
   dashboardRoute?: string
 }>) {
   const [isOpen, setIsOpen] = useState(open)
+  const [hasMounted, setHasMounted] = useState(false)
 
   useEffect(() => {
     setIsOpen(open)
   }, [open])
+
+  useEffect(() => {
+    setHasMounted(true)
+  }, [])
+
+  if (!hasMounted) {
+    return children
+  }
 
   return (
     <Dialog


### PR DESCRIPTION
## Summary
- Delay the Pro upgrade dialog wrapper until after hydration so Radix dialog IDs do not diverge between SSR and the client.
- 
## Testing
- Added a regression test for `UpgradeDialog` SSR output.
- Lint and formatting passed.