### PR TITLE
feat: adjust publishedAt sorting

### DIFF
--- a/.changeset/fix-documents-table-sort-column.md
+++ b/.changeset/fix-documents-table-sort-column.md
@@ -1,0 +1,5 @@
+---
+'outstatic': patch
+---
+
+Fix documents table sort when `publishedAt` is missing from metadata; treat empty dates as oldest when sorting by `publishedAt`.

--- a/packages/outstatic/src/components/documents-table.tsx
+++ b/packages/outstatic/src/components/documents-table.tsx
@@ -19,7 +19,11 @@ import { MDExtensions } from '@/types'
 import { OstDocument } from '@/types/public'
 import { useGetDocuments } from '@/utils/hooks/use-get-documents'
 import { useOutstatic } from '@/utils/hooks/use-outstatic'
-import { publishedAtSortingFn, statusSortingFn } from '@/utils/table-sorting'
+import {
+  publishedAtAccessor,
+  publishedAtSortingFn,
+  statusSortingFn
+} from '@/utils/table-sorting'
 import {
   CaretDownIcon,
   CaretSortIcon,
@@ -50,6 +54,9 @@ const DOCUMENT_COLUMN_LABELS: Record<string, string> = {
   slug: 'Slug',
   publishedAt: 'Published At'
 }
+
+const getDefaultSortColumnId = (columnIds: string[]): string | undefined =>
+  columnIds.includes('publishedAt') ? 'publishedAt' : columnIds[0]
 
 const documentColumnLabel = (id: string): string =>
   DOCUMENT_COLUMN_LABELS[id] ?? sentenceCase(id)
@@ -109,9 +116,7 @@ export const DocumentsTable = () => {
 
   const cookieKey = `ost_${params.ost[0]}_fields`
 
-  const [sorting, setSorting] = useState<SortingState>([
-    { id: 'publishedAt', desc: true }
-  ])
+  const [sorting, setSorting] = useState<SortingState>([])
 
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
 
@@ -121,9 +126,16 @@ export const DocumentsTable = () => {
     () => {
       if (allColumnIds.length === 0) {
         setColumnVisibility({})
+        setSorting([])
         return
       }
       setColumnVisibility(readInitialVisibility(allColumnIds, cookieKey))
+      setSorting((prev) => {
+        const valid = prev.filter((s) => allColumnIds.includes(s.id))
+        if (valid.length > 0) return valid
+        const defaultId = getDefaultSortColumnId(allColumnIds)
+        return defaultId ? [{ id: defaultId, desc: true }] : []
+      })
       // `columnIdsKey` is content-based so metadata Map identity (e.g. new refs per render) does not retrigger.
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- columnIdsKey tracks column order; allColumnIds is a new array when metadata is a new Map reference each render
@@ -134,9 +146,13 @@ export const DocumentsTable = () => {
     () =>
       allColumnIds.map((id) => ({
         id,
-        accessorKey: id,
+        ...(id === 'publishedAt'
+          ? {
+              accessorFn: publishedAtAccessor,
+              sortingFn: publishedAtSortingFn
+            }
+          : { accessorKey: id }),
         enableHiding: true,
-        ...(id === 'publishedAt' && { sortingFn: publishedAtSortingFn }),
         ...(id === 'status' && { sortingFn: statusSortingFn }),
         header: ({ column }) => {
           const sorted = column.getIsSorted()
@@ -168,8 +184,9 @@ export const DocumentsTable = () => {
             </Button>
           )
         },
-        cell: ({ getValue }) => {
-          const value = getValue()
+        cell: ({ getValue, row }) => {
+          const value =
+            id === 'publishedAt' ? row.original.publishedAt : getValue()
           if (id === 'status') {
             return <span data-testid="status-cell">{value as ReactNode}</span>
           }

--- a/packages/outstatic/src/components/singletons-table.tsx
+++ b/packages/outstatic/src/components/singletons-table.tsx
@@ -19,7 +19,11 @@ import {
 import { OstDocument } from '@/types/public'
 import { useOutstatic } from '@/utils/hooks/use-outstatic'
 import { useSingletons } from '@/utils/hooks/use-singletons'
-import { publishedAtSortingFn, statusSortingFn } from '@/utils/table-sorting'
+import {
+  publishedAtAccessor,
+  publishedAtSortingFn,
+  statusSortingFn
+} from '@/utils/table-sorting'
 import {
   CaretDownIcon,
   CaretSortIcon,
@@ -142,7 +146,7 @@ export const SingletonsTable = () => {
   }, [singletonsData])
 
   const [sorting, setSorting] = useState<SortingState>([
-    { id: 'title', desc: false }
+    { id: 'publishedAt', desc: true }
   ])
 
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
@@ -174,9 +178,13 @@ export const SingletonsTable = () => {
     () =>
       COLUMN_DEFINITIONS.map(({ id, label }) => ({
         id,
-        accessorKey: id,
+        ...(id === 'publishedAt'
+          ? {
+              accessorFn: publishedAtAccessor,
+              sortingFn: publishedAtSortingFn
+            }
+          : { accessorKey: id }),
         enableHiding: true,
-        ...(id === 'publishedAt' && { sortingFn: publishedAtSortingFn }),
         ...(id === 'status' && { sortingFn: statusSortingFn }),
         header: ({ column }) => {
           const sorted = column.getIsSorted()
@@ -208,8 +216,11 @@ export const SingletonsTable = () => {
             </Button>
           )
         },
-        cell: ({ getValue }) => {
-          const value = (getValue() as string) ?? null
+        cell: ({ getValue, row }) => {
+          const value =
+            id === 'publishedAt'
+              ? (row.original.publishedAt ?? null)
+              : ((getValue() as string) ?? null)
           if (id === 'title') {
             return value !== null ? (
               <span className="font-semibold">{value}</span>

--- a/packages/outstatic/src/components/tests/documents-table.test.tsx
+++ b/packages/outstatic/src/components/tests/documents-table.test.tsx
@@ -40,49 +40,62 @@ jest.mock('change-case', () => {
 const date1 = 'July 14, 2022'
 const date2 = 'August 15, 2023'
 
-jest.mock('@/utils/hooks/use-get-documents', () => ({
-  useGetDocuments: () => ({
-    data: {
-      documents: [
-        {
-          slug: 'doc1',
-          title: 'Document 1',
-          status: 'published',
-          publishedAt: date1,
-          author: { name: 'Andre' },
-          content: 'Test content',
-          collection: 'testCollection'
-        },
-        {
-          slug: 'doc2',
-          title: 'Document 2',
-          status: 'draft',
-          publishedAt: date2,
-          author: { name: 'Filipe' },
-          content: 'Test content',
-          collection: 'testCollection'
-        }
-      ],
-      metadata: new Map(
-        new Map([
-          ['title', 'string'],
-          ['publishedAt', 'string'],
-          ['status', 'string'],
-          ['author', 'string'],
-          ['slug', 'string'],
-          ['extension', 'string'],
-          ['description', 'string']
-        ])
-      )
+type MockGetDocumentsData = {
+  documents: Record<string, unknown>[]
+  metadata: Map<string, string>
+}
+
+const defaultDocumentsData: MockGetDocumentsData = {
+  documents: [
+    {
+      slug: 'doc1',
+      title: 'Document 1',
+      status: 'published',
+      publishedAt: date1,
+      author: { name: 'Andre' },
+      content: 'Test content',
+      collection: 'testCollection'
     },
+    {
+      slug: 'doc2',
+      title: 'Document 2',
+      status: 'draft',
+      publishedAt: date2,
+      author: { name: 'Filipe' },
+      content: 'Test content',
+      collection: 'testCollection'
+    }
+  ],
+  metadata: new Map([
+    ['title', 'string'],
+    ['publishedAt', 'string'],
+    ['status', 'string'],
+    ['author', 'string'],
+    ['slug', 'string'],
+    ['extension', 'string'],
+    ['description', 'string']
+  ])
+}
+
+const mockUseGetDocuments = jest.fn(
+  (): { data: MockGetDocumentsData; refetch: jest.Mock } => ({
+    data: defaultDocumentsData,
     refetch: jest.fn()
   })
+)
+
+jest.mock('@/utils/hooks/use-get-documents', () => ({
+  useGetDocuments: () => mockUseGetDocuments()
 }))
 
 describe('DocumentsTable', () => {
   beforeEach(() => {
     mockRouter.push.mockClear()
     ;(Cookies.set as jest.Mock).mockClear()
+    mockUseGetDocuments.mockImplementation(() => ({
+      data: defaultDocumentsData,
+      refetch: jest.fn()
+    }))
   })
 
   it('renders a table with provided documents', () => {
@@ -224,6 +237,53 @@ describe('DocumentsTable', () => {
     expect(mockRouter.push).not.toHaveBeenCalled()
 
     openSpy.mockRestore()
+  })
+
+  it('does not error when publishedAt is not in metadata (sorts by first column)', () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
+    mockUseGetDocuments.mockImplementation(() => ({
+      data: {
+        documents: [
+          {
+            slug: 'doc1',
+            title: 'Document 1',
+            status: 'published',
+            date: date1,
+            content: '',
+            collection: 'testCollection'
+          }
+        ],
+        metadata: new Map([
+          ['title', 'string'],
+          ['date', 'string'],
+          ['status', 'string'],
+          ['slug', 'string']
+        ])
+      },
+      refetch: jest.fn()
+    }))
+
+    render(
+      <TestWrapper>
+        <DocumentsTable />
+      </TestWrapper>
+    )
+
+    expect(screen.getByText('Document 1')).toBeInTheDocument()
+    expect(screen.getByTestId('sort-icon-title')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('sort-icon-publishedAt')
+    ).not.toBeInTheDocument()
+
+    const tableErrors = consoleError.mock.calls.filter((args) =>
+      String(args[0]).includes("Column with id 'publishedAt'")
+    )
+    expect(tableErrors).toHaveLength(0)
+
+    consoleError.mockRestore()
   })
 
   it('persists visible columns via js-cookie when toggling the Columns menu', async () => {

--- a/packages/outstatic/src/components/tests/singletons-table.test.tsx
+++ b/packages/outstatic/src/components/tests/singletons-table.test.tsx
@@ -110,7 +110,7 @@ describe('SingletonsTable', () => {
       </TestWrapper>
     )
 
-    // Default sort is by title ascending
+    expect(screen.getByTestId('sort-icon-publishedAt')).toBeInTheDocument()
     expect(screen.getByTestId('sort-icon-title')).toBeInTheDocument()
   })
 
@@ -121,14 +121,13 @@ describe('SingletonsTable', () => {
       </TestWrapper>
     )
 
-    const titleHeader = screen.getByText('Title')
+    const publishedAtHeader = screen.getByText('Published At')
 
-    // Initially ascending
-    expect(screen.getByTestId('caret-up-icon')).toBeInTheDocument()
-
-    // Click to toggle to descending
-    fireEvent.click(titleHeader)
+    // Default sort is publishedAt descending
     expect(screen.getByTestId('caret-down-icon')).toBeInTheDocument()
+
+    fireEvent.click(publishedAtHeader)
+    expect(screen.getByTestId('caret-up-icon')).toBeInTheDocument()
   })
 
   it('renders an actions trigger for each singleton', () => {

--- a/packages/outstatic/src/utils/table-sorting.ts
+++ b/packages/outstatic/src/utils/table-sorting.ts
@@ -1,16 +1,31 @@
 import type { OstDocument } from '@/types/public'
 import type { Row } from '@tanstack/react-table'
 
+export function publishedAtSortTime(value: unknown): number {
+  if (value == null || value === '' || value === 0) return 0
+  const time = new Date(String(value)).getTime()
+  return Number.isNaN(time) ? 0 : time
+}
+
+export const publishedAtAccessor = <
+  TRow extends { publishedAt?: string | null }
+>(
+  row: TRow
+): string | number => {
+  const value = row.publishedAt
+  if (value == null || value === '') return 0
+  return value
+}
+
 export function publishedAtSortingFn<TData extends Record<string, unknown>>(
   rowA: Row<TData>,
   rowB: Row<TData>,
   columnId: string
 ): number {
-  const a = rowA.getValue<string>(columnId)
-  const b = rowB.getValue<string>(columnId)
-  const dateA = a ? new Date(a).getTime() : 0
-  const dateB = b ? new Date(b).getTime() : 0
-  return dateA - dateB
+  return (
+    publishedAtSortTime(rowA.getValue(columnId)) -
+    publishedAtSortTime(rowB.getValue(columnId))
+  )
 }
 
 type StatusSortable = Pick<OstDocument, 'status' | 'title'>


### PR DESCRIPTION
# Fix documents table sort when publishedAt column is missing

## Summary

Fixes a console error on collection list pages: **`[Table] Column with id 'publishedAt' does not exist`**.

The documents table builds columns from collection metadata, but default sorting was always `publishedAt`. Collections without that field (or where only some documents define it) broke TanStack Table.

**Changes:**

- Default sort is **`publishedAt` (desc)** when the column exists in metadata; otherwise the **first column**.
- Sorting state is initialized only after metadata loads, and invalid sort columns are cleared.
- Missing/empty `publishedAt` values sort as **oldest** (`0`), so dated documents stay above undated ones when sorting newest-first.
- Shared helpers in `table-sorting.ts`: `publishedAtAccessor`, `publishedAtSortTime`, `publishedAtSortingFn` (used by documents and singletons tables).
- Tests updated for collections without `publishedAt` and for singleton default sort.

## Test plan

- [ ] Open a collection where **no documents** use `publishedAt` — list loads with no console error; table sorts by the first column.
- [ ] Open a collection where **some documents** have `publishedAt` and others don't — default sort by Published At (desc); undated rows appear below dated ones.
- [ ] Open a collection where **all documents** have `publishedAt` — default sort unchanged (newest first).
- [ ] Singletons list — default sort by Published At (desc); empty dates sort last.
- [ ] `pnpm typecheck` and `pnpm test --filter=outstatic` pass.
