### PR TITLE
Feat/add collection parents v1

### DIFF
--- a/.changeset/flat-collections-parent.md
+++ b/.changeset/flat-collections-parent.md
@@ -4,3 +4,4 @@
 
 - Store collection hierarchy with parent references and render nested collections in the sidebar.
 - Preserve child collections when deleting a parent unless child deletion is selected.
+- Validate nested navigation child routes recursively.

--- a/.changeset/flat-collections-parent.md
+++ b/.changeset/flat-collections-parent.md
@@ -2,4 +2,5 @@
 'outstatic': patch
 ---
 
-Store collection hierarchy with parent references and render nested collections in the sidebar.
+- Store collection hierarchy with parent references and render nested collections in the sidebar.
+- Preserve child collections when deleting a parent unless child deletion is selected.

--- a/.changeset/flat-collections-parent.md
+++ b/.changeset/flat-collections-parent.md
@@ -1,0 +1,5 @@
+---
+'outstatic': patch
+---
+
+Store collection hierarchy with parent references and render nested collections in the sidebar.

--- a/.changeset/validate-navigation-subchildren.md
+++ b/.changeset/validate-navigation-subchildren.md
@@ -1,0 +1,5 @@
+---
+'outstatic': patch
+---
+
+Validate nested navigation child routes recursively.

--- a/.changeset/validate-navigation-subchildren.md
+++ b/.changeset/validate-navigation-subchildren.md
@@ -1,5 +1,0 @@
----
-'outstatic': patch
----
-
-Validate nested navigation child routes recursively.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   react-to-comment:
     if: >
-      github.repository_id == secrets.CLAUDE_REVIEW_REPOSITORY_ID &&
+      github.repository_id == vars.CLAUDE_REVIEW_REPOSITORY_ID &&
       (
         (github.event_name == 'issue_comment' &&
          github.event.issue.pull_request &&
@@ -35,7 +35,7 @@ jobs:
 
   claude-review:
     if: >
-      github.repository_id == secrets.CLAUDE_REVIEW_REPOSITORY_ID &&
+      github.repository_id == vars.CLAUDE_REVIEW_REPOSITORY_ID &&
       (
         (github.event_name == 'pull_request' && github.event.action == 'opened') ||
         (github.event_name == 'issue_comment' &&

--- a/apps/dev/outstatic/content/collections.json
+++ b/apps/dev/outstatic/content/collections.json
@@ -3,12 +3,12 @@
     "title": "Posts",
     "slug": "posts",
     "path": "apps/dev/outstatic/content/posts",
-    "children": []
+    "parent": null
   },
   {
     "title": "Projects",
     "slug": "projects",
     "path": "apps/dev/outstatic/content/projects",
-    "children": []
+    "parent": null
   }
 ]

--- a/apps/docs/outstatic/content/collections.json
+++ b/apps/docs/outstatic/content/collections.json
@@ -3,18 +3,18 @@
     "title": "Docs",
     "slug": "docs",
     "path": "apps/docs/outstatic/content/docs",
-    "children": []
+    "parent": null
   },
   {
     "title": "Menus",
     "slug": "menus",
     "path": "apps/docs/outstatic/content/menus",
-    "children": []
+    "parent": null
   },
   {
     "title": "V1.4",
     "slug": "v1.4",
     "path": "apps/docs/outstatic/content/v1.4",
-    "children": []
+    "parent": null
   }
 ]

--- a/examples/advanced-blog/outstatic/config.json
+++ b/examples/advanced-blog/outstatic/config.json
@@ -1,5 +1,5 @@
 {
-  "mdExtension": "mdx",
+  "mdExtension": "md",
   "media": [
     {
       "categories": [

--- a/examples/advanced-blog/outstatic/content/collections.json
+++ b/examples/advanced-blog/outstatic/content/collections.json
@@ -3,18 +3,18 @@
     "title": "Pages",
     "slug": "pages",
     "path": "outstatic/content/pages",
-    "children": []
+    "parent": null
   },
   {
     "title": "Posts",
     "slug": "posts",
     "path": "outstatic/content/posts",
-    "children": []
+    "parent": null
   },
   {
     "title": "Projects",
     "slug": "projects",
     "path": "outstatic/content/projects",
-    "children": []
+    "parent": null
   }
 ]

--- a/examples/advanced-blog/outstatic/content/metadata.json
+++ b/examples/advanced-blog/outstatic/content/metadata.json
@@ -1,35 +1,7 @@
 {
-  "commit": "",
-  "generated": "Tue, 12 May 2026 23:52:21 GMT",
+  "commit": "368c2479ba195336e5459320085bb12e50a7765b",
+  "generated": "2026-06-01T19:02:57.168Z",
   "metadata": [
-    {
-      "__outstatic": {
-        "commit": "056337c6ec4b1a28f693f8068e1a116eaef5f7e7",
-        "hash": "2721406306",
-        "path": "/outstatic/content/posts/add-a-free-cms-to-your-nextjs-website-with-outstatic.md"
-      },
-      "author": {
-        "name": "Andre Vitorio",
-        "picture": "https://avatars.githubusercontent.com/u/1417109?v=4"
-      },
-      "collection": "posts",
-      "coverImage": "/images/outstatic-landing-M3MT.png",
-      "description": "Learn how to seamlessly integrate Outstatic into your Next.js website.",
-      "publishedAt": "2024-01-11T20:59:36.724Z",
-      "slug": "add-a-free-cms-to-your-nextjs-website-with-outstatic",
-      "status": "published",
-      "tags": [
-        {
-          "label": "Outstatic",
-          "value": "outstatic"
-        },
-        {
-          "label": "NextJs",
-          "value": "nextJs"
-        }
-      ],
-      "title": "Add a free CMS to your Next.js website with Outstatic"
-    },
     {
       "__outstatic": {
         "commit": "70f53378cbe8e23e9e155748f6102aa28a8a4067",
@@ -189,6 +161,34 @@
         }
       ],
       "title": "Welcome to Outstatic!"
+    },
+    {
+      "__outstatic": {
+        "commit": "368c2479ba195336e5459320085bb12e50a7765b",
+        "hash": "1306649620",
+        "path": "outstatic/content/posts/add-a-free-cms-to-your-nextjs-website-with-outstatic.md"
+      },
+      "author": {
+        "name": "Andre Vitorio",
+        "picture": "https://avatars.githubusercontent.com/u/1417109?v=4"
+      },
+      "collection": "posts",
+      "coverImage": "/images/outstatic-landing-M3MT.png",
+      "description": "Learn how to seamlessly integrate Outstatic into your Next.js website.",
+      "publishedAt": "2026-01-07T03:00:00.000Z",
+      "slug": "add-a-free-cms-to-your-nextjs-website-with-outstatic",
+      "status": "published",
+      "tags": [
+        {
+          "label": "Outstatic",
+          "value": "outstatic"
+        },
+        {
+          "label": "NextJs",
+          "value": "nextJs"
+        }
+      ],
+      "title": "Add a free CMS to your Next.js website with Outstatic"
     }
   ]
 }

--- a/examples/advanced-blog/outstatic/content/posts/add-a-free-cms-to-your-nextjs-website-with-outstatic.md
+++ b/examples/advanced-blog/outstatic/content/posts/add-a-free-cms-to-your-nextjs-website-with-outstatic.md
@@ -1,19 +1,23 @@
 ---
-title: 'Add a free CMS to your Next.js website with Outstatic'
-status: 'published'
+title: Add a free CMS to your Next.js website with Outstatic
+status: published
 author:
-  name: 'Andre Vitorio'
-  picture: 'https://avatars.githubusercontent.com/u/1417109?v=4'
-slug: 'add-a-free-cms-to-your-nextjs-website-with-outstatic'
-description: 'Learn how to seamlessly integrate Outstatic into your Next.js website.'
-coverImage: '/images/outstatic-landing-M3MT.png'
-tags: [{"value":"outstatic","label":"Outstatic"},{"value":"nextJs","label":"NextJs"}]
-publishedAt: '2024-01-11T20:59:36.724Z'
+  name: Andre Vitorio
+  picture: https://avatars.githubusercontent.com/u/1417109?v=4
+slug: add-a-free-cms-to-your-nextjs-website-with-outstatic
+description: Learn how to seamlessly integrate Outstatic into your Next.js website.
+coverImage: /images/outstatic-landing-M3MT.png
+tags:
+  - value: outstatic
+    label: Outstatic
+  - value: nextJs
+    label: NextJs
+publishedAt: 2026-01-07T03:00:00.000Z
 ---
 
 In this blog post, we will explore the step-by-step process of integrating Outstatic into a Next.js website, allowing for efficient content management and improved performance. The installation should take less than 10 minutes.
 
-Requirements: A Next.js 13+ website and a GitHub Account.
+Requirements: A Next.js 15+ website and a GitHub Account.
 
 ## Setting up a GitHub OAuth Application:
 
@@ -101,8 +105,6 @@ OST_REPO_BRANCH=YOUR_GITHUB_REPOSITORY_BRANCH
 Restart your service and reload the `/outstatic` page.
 
 If everything is setup correctly, then you'll see a login page and will be able to access your Dashboard.
-
-![](https://outstatic.com/images/outstatic-login-screen-I4Mz.png)
 
 Now that you have completed the installation and setup process of Outstatic, you can start creating content for your website.
 

--- a/examples/advanced-blog/outstatic/media/media.json
+++ b/examples/advanced-blog/outstatic/media/media.json
@@ -1,0 +1,174 @@
+{
+  "commit": "",
+  "generated": "2026-06-01T18:51:12.132Z",
+  "media": [
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "4281372243",
+        "path": "public/images/1500x500-Q3ND.webp"
+      },
+      "alt": "",
+      "filename": "1500x500-Q3ND.webp",
+      "publishedAt": "2026-06-01T18:51:11.335Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "83154328",
+        "path": "public/images/demo--dark-mode--IyOD.png"
+      },
+      "alt": "",
+      "filename": "demo--dark-mode--IyOD.png",
+      "publishedAt": "2026-06-01T18:51:11.335Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "2409562284",
+        "path": "public/images/e6b70073-0b98-435e-9577-a285d3f431fa-I3MD.png"
+      },
+      "alt": "",
+      "filename": "e6b70073-0b98-435e-9577-a285d3f431fa-I3MD.png",
+      "publishedAt": "2026-06-01T18:51:11.335Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "1067599583",
+        "path": "public/images/image-IwOT.png"
+      },
+      "alt": "",
+      "filename": "image-IwOT.png",
+      "publishedAt": "2026-06-01T18:51:11.335Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "669663276",
+        "path": "public/images/image-M2Nj.png"
+      },
+      "alt": "",
+      "filename": "image-M2Nj.png",
+      "publishedAt": "2026-06-01T18:51:11.335Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "371196896",
+        "path": "public/images/image-QyOT.png"
+      },
+      "alt": "",
+      "filename": "image-QyOT.png",
+      "publishedAt": "2026-06-01T18:51:11.335Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "3103258997",
+        "path": "public/images/image-UwND.png"
+      },
+      "alt": "",
+      "filename": "image-UwND.png",
+      "publishedAt": "2026-06-01T18:51:11.335Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "1375945194",
+        "path": "public/images/image-UyND.png"
+      },
+      "alt": "",
+      "filename": "image-UyND.png",
+      "publishedAt": "2026-06-01T18:51:11.335Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "138591215",
+        "path": "public/images/image-cwND.png"
+      },
+      "alt": "",
+      "filename": "image-cwND.png",
+      "publishedAt": "2026-06-01T18:51:11.335Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "3784473997",
+        "path": "public/images/outside-simulator-I5MD.webp"
+      },
+      "alt": "",
+      "filename": "outside-simulator-I5MD.webp",
+      "publishedAt": "2026-06-01T18:51:11.335Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "2490596413",
+        "path": "public/images/outstatic-landing-M3MT.png"
+      },
+      "alt": "",
+      "filename": "outstatic-landing-M3MT.png",
+      "publishedAt": "2026-06-01T18:51:11.335Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "500099226",
+        "path": "public/images/outstatic-screenshot-Y0ND.png"
+      },
+      "alt": "",
+      "filename": "outstatic-screenshot-Y0ND.png",
+      "publishedAt": "2026-06-01T18:51:11.335Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "4180281951",
+        "path": "public/images/skyline.png"
+      },
+      "alt": "",
+      "filename": "skyline.png",
+      "publishedAt": "2026-06-01T18:51:11.335Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "3597778456",
+        "path": "public/images/welcome-to-outstatic-g3Mz.png"
+      },
+      "alt": "",
+      "filename": "welcome-to-outstatic-g3Mz.png",
+      "publishedAt": "2026-06-01T18:51:11.335Z",
+      "source": "images",
+      "type": "image"
+    }
+  ]
+}

--- a/examples/basic-blog/outstatic/content/collections.json
+++ b/examples/basic-blog/outstatic/content/collections.json
@@ -3,18 +3,18 @@
     "title": "Pages",
     "slug": "pages",
     "path": "outstatic/content/pages",
-    "children": []
+    "parent": null
   },
   {
     "title": "Posts",
     "slug": "posts",
     "path": "outstatic/content/posts",
-    "children": []
+    "parent": null
   },
   {
     "title": "Projects",
     "slug": "projects",
     "path": "outstatic/content/projects",
-    "children": []
+    "parent": null
   }
 ]

--- a/examples/basic-blog/outstatic/media/media.json
+++ b/examples/basic-blog/outstatic/media/media.json
@@ -1,0 +1,90 @@
+{
+  "commit": "",
+  "generated": "2026-06-01T18:49:45.223Z",
+  "media": [
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "89881508",
+        "path": "public/images/bearbnb.png"
+      },
+      "alt": "",
+      "filename": "bearbnb.png",
+      "publishedAt": "2026-06-01T18:49:44.453Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "721419546",
+        "path": "public/images/couple-pizza.png"
+      },
+      "alt": "",
+      "filename": "couple-pizza.png",
+      "publishedAt": "2026-06-01T18:49:44.453Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "3248710460",
+        "path": "public/images/flycream-travel.png"
+      },
+      "alt": "",
+      "filename": "flycream-travel.png",
+      "publishedAt": "2026-06-01T18:49:44.453Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "2691425336",
+        "path": "public/images/industrial-pattern.png"
+      },
+      "alt": "",
+      "filename": "industrial-pattern.png",
+      "publishedAt": "2026-06-01T18:49:44.453Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "1342721826",
+        "path": "public/images/jupiter-spaceship.png"
+      },
+      "alt": "",
+      "filename": "jupiter-spaceship.png",
+      "publishedAt": "2026-06-01T18:49:44.453Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "4106799444",
+        "path": "public/images/og-image.png"
+      },
+      "alt": "",
+      "filename": "og-image.png",
+      "publishedAt": "2026-06-01T18:49:44.453Z",
+      "source": "images",
+      "type": "image"
+    },
+    {
+      "__outstatic": {
+        "commit": "",
+        "hash": "4180281951",
+        "path": "public/images/skyline.png"
+      },
+      "alt": "",
+      "filename": "skyline.png",
+      "publishedAt": "2026-06-01T18:49:44.453Z",
+      "source": "images",
+      "type": "image"
+    }
+  ]
+}

--- a/examples/docs/outstatic/content/collections.json
+++ b/examples/docs/outstatic/content/collections.json
@@ -3,18 +3,18 @@
     "title": "Docs",
     "slug": "docs",
     "path": "outstatic/content/docs",
-    "children": []
+    "parent": null
   },
   {
     "title": "Menus",
     "slug": "menus",
     "path": "outstatic/content/menus",
-    "children": []
+    "parent": null
   },
   {
     "title": "V1.4",
     "slug": "v1.4",
     "path": "outstatic/content/v1.4",
-    "children": []
+    "parent": null
   }
 ]

--- a/packages/outstatic/src/client/pages/__tests__/custom-fields.test.tsx
+++ b/packages/outstatic/src/client/pages/__tests__/custom-fields.test.tsx
@@ -6,6 +6,8 @@ const mockUseOutstatic = jest.fn()
 const mockUseCollections = jest.fn()
 const mockUseSingletons = jest.fn()
 const mockUsePermissions = jest.fn()
+const mockFetchOid = jest.fn()
+const mockCreateCommitMutateAsync = jest.fn()
 
 jest.mock('@/utils/hooks/use-field-schema', () => ({
   useFieldSchema: () => mockUseFieldSchema()
@@ -22,6 +24,15 @@ jest.mock('@/utils/hooks/use-permissions', () => ({
 }))
 jest.mock('@/utils/hooks/use-field-schema-commit', () => ({
   useFieldSchemaCommit: () => jest.fn()
+}))
+jest.mock('@/utils/hooks/use-oid', () => ({
+  __esModule: true,
+  default: () => mockFetchOid
+}))
+jest.mock('@/utils/hooks/use-create-commit', () => ({
+  useCreateCommit: () => ({
+    mutateAsync: mockCreateCommitMutateAsync
+  })
 }))
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(() => ({
@@ -67,6 +78,8 @@ describe('<CustomFields />', () => {
     mockUseOutstatic.mockReturnValue({
       dashboardRoute: '/outstatic'
     })
+    mockFetchOid.mockResolvedValue('oid')
+    mockCreateCommitMutateAsync.mockResolvedValue({})
   })
 
   it('renders the unauthorized state when collections.manage is missing', () => {

--- a/packages/outstatic/src/client/pages/_components/__tests__/field-management-page.test.tsx
+++ b/packages/outstatic/src/client/pages/_components/__tests__/field-management-page.test.tsx
@@ -7,6 +7,8 @@ const mockUseCollections = jest.fn()
 const mockUseOutstatic = jest.fn()
 const mockUseSingletons = jest.fn()
 const mockCommitFieldSchema = jest.fn()
+const mockFetchOid = jest.fn()
+const mockCreateCommitMutateAsync = jest.fn()
 let mockDragEndEvent: any = null
 
 jest.mock('@/utils/hooks/use-field-schema', () => ({
@@ -24,6 +26,17 @@ jest.mock('@/utils/hooks/use-singletons', () => ({
 
 jest.mock('@/utils/hooks/use-field-schema-commit', () => ({
   useFieldSchemaCommit: () => mockCommitFieldSchema
+}))
+
+jest.mock('@/utils/hooks/use-oid', () => ({
+  __esModule: true,
+  default: () => mockFetchOid
+}))
+
+jest.mock('@/utils/hooks/use-create-commit', () => ({
+  useCreateCommit: () => ({
+    mutateAsync: mockCreateCommitMutateAsync
+  })
 }))
 
 jest.mock('@dnd-kit/core', () => ({
@@ -149,6 +162,8 @@ describe('<FieldManagementPage />', () => {
     })
 
     mockCommitFieldSchema.mockResolvedValue(true)
+    mockFetchOid.mockResolvedValue('oid')
+    mockCreateCommitMutateAsync.mockResolvedValue({})
   })
 
   it('does not block singleton pages on a disabled collections query', () => {

--- a/packages/outstatic/src/client/pages/_components/__tests__/field-management-page.test.tsx
+++ b/packages/outstatic/src/client/pages/_components/__tests__/field-management-page.test.tsx
@@ -9,6 +9,10 @@ const mockUseSingletons = jest.fn()
 const mockCommitFieldSchema = jest.fn()
 const mockFetchOid = jest.fn()
 const mockCreateCommitMutateAsync = jest.fn()
+const mockRefetchCollections = jest.fn()
+const mockToastPromise = jest.fn()
+const mockToastError = jest.fn()
+const mockToastMessage = jest.fn()
 let mockDragEndEvent: any = null
 
 jest.mock('@/utils/hooks/use-field-schema', () => ({
@@ -38,6 +42,70 @@ jest.mock('@/utils/hooks/use-create-commit', () => ({
     mutateAsync: mockCreateCommitMutateAsync
   })
 }))
+
+jest.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    message: (...args: unknown[]) => mockToastMessage(...args),
+    promise: (...args: unknown[]) => mockToastPromise(...args)
+  }
+}))
+
+jest.mock('@/components/ui/shadcn/select', () => {
+  const React = jest.requireActual<typeof import('react')>('react')
+  const SelectContext = React.createContext<{
+    onValueChange?: (value: string) => void
+  }>({})
+
+  const Select = ({
+    children,
+    onValueChange
+  }: {
+    children: any
+    onValueChange?: (value: string) => void
+    value?: string
+    disabled?: boolean
+  }) => (
+    <SelectContext.Provider value={{ onValueChange }}>
+      <div>{children}</div>
+    </SelectContext.Provider>
+  )
+
+  const SelectTrigger = ({ children, ...props }: { children: any }) => (
+    <button type="button" role="combobox" {...props}>
+      {children}
+    </button>
+  )
+
+  const SelectValue = ({ placeholder }: { placeholder?: string }) => (
+    <span>{placeholder ?? ''}</span>
+  )
+
+  const SelectContent = ({ children }: { children: any }) => <div>{children}</div>
+
+  const SelectItem = ({
+    children,
+    value
+  }: {
+    children: any
+    value: string
+  }) => {
+    const { onValueChange } = React.useContext(SelectContext)
+    return (
+      <button
+        type="button"
+        role="option"
+        aria-selected="false"
+        data-value={value}
+        onClick={() => onValueChange?.(value)}
+      >
+        {children}
+      </button>
+    )
+  }
+
+  return { Select, SelectTrigger, SelectValue, SelectContent, SelectItem }
+})
 
 jest.mock('@dnd-kit/core', () => ({
   DndContext: ({
@@ -147,9 +215,11 @@ describe('<FieldManagementPage />', () => {
       isLoading: false
     })
 
+    mockRefetchCollections.mockResolvedValue({ data: [] })
     mockUseCollections.mockReturnValue({
       data: [],
-      isPending: false
+      isPending: false,
+      refetch: mockRefetchCollections
     })
 
     mockUseSingletons.mockReturnValue({
@@ -158,12 +228,18 @@ describe('<FieldManagementPage />', () => {
     })
 
     mockUseOutstatic.mockReturnValue({
-      dashboardRoute: '/outstatic'
+      dashboardRoute: '/outstatic',
+      ostContent: 'outstatic/content',
+      repoOwner: 'acme',
+      repoSlug: 'site',
+      repoBranch: 'main',
+      session: { user: { login: 'acme' } }
     })
 
     mockCommitFieldSchema.mockResolvedValue(true)
     mockFetchOid.mockResolvedValue('oid')
     mockCreateCommitMutateAsync.mockResolvedValue({})
+    mockToastPromise.mockImplementation((promise: Promise<unknown>) => promise)
   })
 
   it('does not block singleton pages on a disabled collections query', () => {
@@ -452,5 +528,145 @@ describe('<FieldManagementPage />', () => {
     expect(
       screen.queryByText('Custom fields order modified.')
     ).not.toBeInTheDocument()
+  })
+
+  describe('parent collection save', () => {
+    const collections = [
+      {
+        slug: 'posts',
+        title: 'Posts',
+        path: 'outstatic/content/posts',
+        parent: null
+      },
+      {
+        slug: 'guides',
+        title: 'Guides',
+        path: 'outstatic/content/guides',
+        parent: null
+      }
+    ]
+
+    const renderPage = () => {
+      mockUseCollections.mockReturnValue({
+        data: collections,
+        isPending: false,
+        refetch: mockRefetchCollections
+      })
+      mockRefetchCollections.mockResolvedValue({ data: collections })
+
+      return render(
+        <FieldManagementPage
+          target={{ kind: 'collection', slug: 'posts', title: 'Posts' }}
+          emptyStateSubject="collection"
+        />
+      )
+    }
+
+    it('disables the Update button when no parent change is pending', () => {
+      renderPage()
+
+      const updateButtons = screen.getAllByRole('button', { name: 'Update' })
+      expect(updateButtons[0]).toBeDisabled()
+    })
+
+    it('commits the parent change and refetches collections on save', async () => {
+      renderPage()
+
+      fireEvent.click(screen.getByRole('option', { name: 'Guides' }))
+
+      const updateButtons = screen.getAllByRole('button', { name: 'Update' })
+      expect(updateButtons[0]).toBeEnabled()
+
+      fireEvent.click(updateButtons[0])
+
+      await waitFor(() => {
+        expect(mockCreateCommitMutateAsync).toHaveBeenCalledTimes(1)
+      })
+
+      const commitInput = mockCreateCommitMutateAsync.mock.calls[0][0]
+      expect(commitInput.branch).toEqual({
+        repositoryNameWithOwner: 'acme/site',
+        branchName: 'main'
+      })
+      expect(commitInput.expectedHeadOid).toBe('oid')
+
+      const collectionsAddition = commitInput.fileChanges.additions.find(
+        (addition: { path: string }) =>
+          addition.path === 'outstatic/content/collections.json'
+      )
+      expect(collectionsAddition).toBeDefined()
+
+      const decoded = JSON.parse(
+        Buffer.from(collectionsAddition.contents, 'base64').toString('utf-8')
+      )
+      expect(decoded).toEqual([
+        { ...collections[0], parent: 'guides' },
+        collections[1]
+      ])
+
+      expect(mockToastPromise).toHaveBeenCalled()
+      await waitFor(() => {
+        expect(mockRefetchCollections).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    it('shows an error toast when the commit fails', async () => {
+      mockCreateCommitMutateAsync.mockRejectedValueOnce(new Error('boom'))
+      const consoleError = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      renderPage()
+
+      fireEvent.click(screen.getByRole('option', { name: 'Guides' }))
+      const updateButtons = screen.getAllByRole('button', { name: 'Update' })
+      fireEvent.click(updateButtons[0])
+
+      await waitFor(() => {
+        expect(mockToastError).toHaveBeenCalledWith(
+          'Failed to update parent collection.',
+          expect.objectContaining({
+            action: expect.objectContaining({ label: 'Copy Logs' })
+          })
+        )
+      })
+
+      consoleError.mockRestore()
+    })
+
+    it('locks out parent save while custom field order has unsaved changes', async () => {
+      mockUseFieldSchema.mockReturnValue({
+        data: {
+          properties: {
+            title: { title: 'Title', fieldType: 'String', dataType: 'string' },
+            featured: {
+              title: 'Featured',
+              fieldType: 'Boolean',
+              dataType: 'boolean'
+            }
+          }
+        },
+        isLoading: false
+      })
+
+      mockDragEndEvent = { active: { id: 'featured' }, over: { id: 'title' } }
+
+      renderPage()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Trigger drag end' }))
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Custom fields order modified.')
+        ).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByRole('option', { name: 'Guides' }))
+
+      const parentUpdateButton = screen.getAllByRole('button', {
+        name: 'Update'
+      })[0]
+      expect(parentUpdateButton).toBeDisabled()
+    })
   })
 })

--- a/packages/outstatic/src/client/pages/_components/__tests__/field-management-page.test.tsx
+++ b/packages/outstatic/src/client/pages/_components/__tests__/field-management-page.test.tsx
@@ -81,7 +81,9 @@ jest.mock('@/components/ui/shadcn/select', () => {
     <span>{placeholder ?? ''}</span>
   )
 
-  const SelectContent = ({ children }: { children: any }) => <div>{children}</div>
+  const SelectContent = ({ children }: { children: any }) => (
+    <div>{children}</div>
+  )
 
   const SelectItem = ({
     children,

--- a/packages/outstatic/src/client/pages/_components/field-management-page.tsx
+++ b/packages/outstatic/src/client/pages/_components/field-management-page.tsx
@@ -190,7 +190,7 @@ export const FieldManagementPage = ({
     return getValidParentCollectionOptions(collections, target.slug).sort(
       (a, b) => a.title.localeCompare(b.title)
     )
-  }, [collections, target])
+  }, [collections, target.kind, target.slug])
   const hasPendingParentChange =
     target.kind === 'collection' &&
     collection !== undefined &&

--- a/packages/outstatic/src/client/pages/_components/field-management-page.tsx
+++ b/packages/outstatic/src/client/pages/_components/field-management-page.tsx
@@ -2,7 +2,7 @@ import { type DragEndEvent, DndContext } from '@dnd-kit/core'
 import { restrictToParentElement } from '@dnd-kit/modifiers'
 import { SortableContext, useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { GripVertical, Trash } from 'lucide-react'
 import { AdminLayout } from '@/components/admin-layout'
 import { AdminLoading } from '@/components/admin-loading'
@@ -34,6 +34,26 @@ import { useSingletons } from '@/utils/hooks/use-singletons'
 import { useRouter } from 'next/navigation'
 import { reorderCustomFields } from './field-reorder'
 import { Badge } from '@/components/ui/shadcn/badge'
+import { Label } from '@/components/ui/shadcn/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/shadcn/select'
+import { createCommitApi } from '@/utils/create-commit-api'
+import { createOutstaticCommitMessage } from '@/utils/commit-message'
+import { useCreateCommit } from '@/utils/hooks/use-create-commit'
+import useOid from '@/utils/hooks/use-oid'
+import { stringifyError } from '@/utils/errors/stringify-error'
+import {
+  getValidParentCollectionOptions,
+  updateCollectionParent
+} from '@/utils/collections/collection-tree'
+import { toast } from 'sonner'
+
+const NO_PARENT_COLLECTION_VALUE = '__none__'
 
 type SortableFieldCardProps = {
   name: string
@@ -133,11 +153,26 @@ export const FieldManagementPage = ({
   const [pendingSchemaSettings, setPendingSchemaSettings] =
     useState<FieldSchemaSettings>({})
   const [savingSettings, setSavingSettings] = useState(false)
+  const [pendingParent, setPendingParent] = useState<string | null>(null)
+  const [savingParent, setSavingParent] = useState(false)
   const router = useRouter()
-  const { dashboardRoute } = useOutstatic()
+  const {
+    dashboardRoute,
+    ostContent,
+    repoOwner,
+    repoSlug,
+    repoBranch,
+    session
+  } = useOutstatic()
+  const fetchOid = useOid()
+  const createCommit = useCreateCommit()
   const commitFieldSchema = useFieldSchemaCommit(target)
   const { data: schema, isLoading } = useFieldSchema({ target })
-  const { data: collections, isPending: collectionsPending } = useCollections({
+  const {
+    data: collections,
+    isPending: collectionsPending,
+    refetch: refetchCollections
+  } = useCollections({
     enabled: target.kind === 'collection'
   })
 
@@ -147,6 +182,26 @@ export const FieldManagementPage = ({
   const singleton = singletons?.find((s) => s.slug === target.slug)
   const extension = singleton?.path?.endsWith('.mdx') ? 'mdx' : 'md'
   const collection = collections?.find((c) => c.slug === target.slug)
+  const parentCollectionOptions = useMemo(() => {
+    if (!collections || target.kind !== 'collection') {
+      return []
+    }
+
+    return getValidParentCollectionOptions(collections, target.slug).sort(
+      (a, b) => a.title.localeCompare(b.title)
+    )
+  }, [collections, target])
+  const hasPendingParentChange =
+    target.kind === 'collection' &&
+    collection !== undefined &&
+    pendingParent !== collection.parent
+
+  useEffect(() => {
+    if (collection) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setPendingParent(collection.parent)
+    }
+  }, [collection])
 
   useEffect(() => {
     if (schema) {
@@ -235,6 +290,77 @@ export const FieldManagementPage = ({
     }
 
     setSchemaSettings(pendingSchemaSettings)
+  }
+
+  const handleSaveParent = async () => {
+    if (savingParent || !collection || target.kind !== 'collection') {
+      return
+    }
+
+    setSavingParent(true)
+
+    try {
+      const [{ data: latestCollections }, oid] = await Promise.all([
+        refetchCollections(),
+        fetchOid()
+      ])
+
+      if (!latestCollections) {
+        throw new Error('Failed to fetch collections')
+      }
+
+      if (!oid) {
+        throw new Error('No oid found')
+      }
+
+      const owner = repoOwner || session?.user?.login || ''
+      const updatedCollections = updateCollectionParent(
+        latestCollections,
+        collection.slug,
+        pendingParent
+      )
+
+      const commitApi = createCommitApi({
+        message: createOutstaticCommitMessage({
+          scope: 'config',
+          action: 'update',
+          target: 'collection',
+          label: collection.slug
+        }),
+        owner,
+        oid,
+        name: repoSlug,
+        branch: repoBranch
+      })
+
+      commitApi.replaceFile(
+        `${ostContent}/collections.json`,
+        JSON.stringify(updatedCollections, null, 2) + '\n'
+      )
+
+      await toast.promise(createCommit.mutateAsync(commitApi.createInput()), {
+        loading: 'Updating parent collection...',
+        success: 'Parent collection updated',
+        error: 'Failed to update parent collection'
+      })
+
+      await refetchCollections()
+    } catch (error) {
+      console.error('Failed to update parent collection', error)
+      const errorToast = toast.error('Failed to update parent collection.', {
+        action: {
+          label: 'Copy Logs',
+          onClick: () => {
+            navigator.clipboard.writeText(`Error: ${stringifyError(error)}`)
+            toast.message('Logs copied to clipboard', {
+              id: errorToast
+            })
+          }
+        }
+      })
+    } finally {
+      setSavingParent(false)
+    }
   }
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -372,6 +498,73 @@ export const FieldManagementPage = ({
             </DndContext>
           )}
         </div>
+        {target.kind === 'collection' && collection ? (
+          <div className="flex flex-1 max-w-2xl flex-col space-y-6">
+            <div className="flex items-center">
+              <h2 className="text-xl">Collection</h2>
+            </div>
+            <Card>
+              <CardHeader>
+                <CardTitle>Parent collection</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="parent-collection">Parent collection</Label>
+                  <Select
+                    value={pendingParent ?? NO_PARENT_COLLECTION_VALUE}
+                    disabled={savingParent}
+                    onValueChange={(value) => {
+                      setPendingParent(
+                        value === NO_PARENT_COLLECTION_VALUE ? null : value
+                      )
+                    }}
+                  >
+                    <SelectTrigger id="parent-collection" className="w-full">
+                      <SelectValue placeholder="Select a parent collection" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={NO_PARENT_COLLECTION_VALUE}>
+                        None
+                      </SelectItem>
+                      {parentCollectionOptions.map((parentOption) => (
+                        <SelectItem
+                          key={parentOption.slug}
+                          value={parentOption.slug}
+                        >
+                          {parentOption.title}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-sm text-muted-foreground">
+                    Nest this collection under another in the sidebar. You
+                    cannot select the collection itself or its descendants.
+                  </p>
+                </div>
+              </CardContent>
+              <CardFooter className="justify-start">
+                <Button
+                  type="button"
+                  disabled={
+                    !hasPendingParentChange ||
+                    savingParent ||
+                    hasPendingOrderChange
+                  }
+                  onClick={handleSaveParent}
+                >
+                  {savingParent ? (
+                    <>
+                      <SpinnerIcon className="mr-2 text-background" />
+                      Updating
+                    </>
+                  ) : (
+                    'Update'
+                  )}
+                </Button>
+              </CardFooter>
+            </Card>
+          </div>
+        ) : null}
         <div className="flex flex-1 max-w-2xl flex-col space-y-6">
           <div className="flex items-center">
             <h2 className="text-xl">Editor</h2>

--- a/packages/outstatic/src/client/pages/_components/field-management-page.tsx
+++ b/packages/outstatic/src/client/pages/_components/field-management-page.tsx
@@ -201,7 +201,7 @@ export const FieldManagementPage = ({
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setPendingParent(collection.parent)
     }
-  }, [collection])
+  }, [collection?.slug, collection?.parent])
 
   useEffect(() => {
     if (schema) {

--- a/packages/outstatic/src/client/pages/_components/root-provider.tsx
+++ b/packages/outstatic/src/client/pages/_components/root-provider.tsx
@@ -50,7 +50,7 @@ function RootProviderInner({ ostData, children }: RootProviderProps) {
         defaultTheme="system"
         enableSystem
         disableTransitionOnChange
-        scriptProps={{ type: "application/json" }}
+        scriptProps={{ type: 'application/json' }}
       >
         {showToaster ? <Toaster /> : null}
         <QueryClientProvider client={queryClient}>

--- a/packages/outstatic/src/client/pages/collections/_components/delete-collection-modal.tsx
+++ b/packages/outstatic/src/client/pages/collections/_components/delete-collection-modal.tsx
@@ -21,32 +21,11 @@ import { useOutstatic } from '@/utils/hooks/use-outstatic'
 import { stringifyMetadata } from '@/utils/metadata/stringify'
 import { toast } from 'sonner'
 import { CollectionType, useCollections } from '@/utils/hooks/use-collections'
-
-function getDescendantCollectionSlugs(
-  collections: CollectionType[],
-  parentSlug: string
-) {
-  const descendantSlugs = new Set<string>()
-  let foundDescendant = true
-
-  while (foundDescendant) {
-    foundDescendant = false
-
-    collections.forEach((collection) => {
-      if (
-        collection.parent &&
-        (collection.parent === parentSlug ||
-          descendantSlugs.has(collection.parent)) &&
-        !descendantSlugs.has(collection.slug)
-      ) {
-        descendantSlugs.add(collection.slug)
-        foundDescendant = true
-      }
-    })
-  }
-
-  return descendantSlugs
-}
+import {
+  getCollectionsAfterDeletion,
+  getDescendantCollectionSlugs,
+  getMetadataAfterCollectionDeletion
+} from '@/utils/collections/collection-tree'
 
 type DeleteCollectionModalProps = {
   setShowDeleteModal: (value: boolean) => void
@@ -108,24 +87,11 @@ function DeleteCollectionModal({
       })
 
       if (collections) {
-        const descendantSlugs = getDescendantCollectionSlugs(
+        const newCollections = getCollectionsAfterDeletion(
           collections,
-          collection.slug
+          collection,
+          keepFiles
         )
-        // remove collection from collections.json
-        const newCollections = collections
-          .filter(
-            (collectionInfo) =>
-              collectionInfo.slug !== collection.slug &&
-              (keepFiles || !descendantSlugs.has(collectionInfo.slug))
-          )
-          .map((collectionInfo) => ({
-            ...collectionInfo,
-            parent:
-              collectionInfo.parent === collection.slug
-                ? collection.parent
-                : collectionInfo.parent
-          }))
         capi.replaceFile(
           `${ostContent}/collections.json`,
           JSON.stringify(newCollections, null, 2)
@@ -144,10 +110,11 @@ function DeleteCollectionModal({
         const m = metadata.metadata
         m.generated = new Date().toISOString()
         m.commit = hashFromUrl(metadata.commitUrl)
-        const newMeta = (m.metadata ?? []).filter(
-          (post) =>
-            post.collection !== collection.slug &&
-            (keepFiles || !descendantSlugs.has(post.collection))
+        const newMeta = getMetadataAfterCollectionDeletion(
+          m.metadata ?? [],
+          collection.slug,
+          descendantSlugs,
+          keepFiles
         )
         capi.replaceFile(
           `${ostContent}/metadata.json`,

--- a/packages/outstatic/src/client/pages/collections/_components/delete-collection-modal.tsx
+++ b/packages/outstatic/src/client/pages/collections/_components/delete-collection-modal.tsx
@@ -22,6 +22,32 @@ import { stringifyMetadata } from '@/utils/metadata/stringify'
 import { toast } from 'sonner'
 import { CollectionType, useCollections } from '@/utils/hooks/use-collections'
 
+function getDescendantCollectionSlugs(
+  collections: CollectionType[],
+  parentSlug: string
+) {
+  const descendantSlugs = new Set<string>()
+  let foundDescendant = true
+
+  while (foundDescendant) {
+    foundDescendant = false
+
+    collections.forEach((collection) => {
+      if (
+        collection.parent &&
+        (collection.parent === parentSlug ||
+          descendantSlugs.has(collection.parent)) &&
+        !descendantSlugs.has(collection.slug)
+      ) {
+        descendantSlugs.add(collection.slug)
+        foundDescendant = true
+      }
+    })
+  }
+
+  return descendantSlugs
+}
+
 type DeleteCollectionModalProps = {
   setShowDeleteModal: (value: boolean) => void
   setSelectedCollection?: (value: CollectionType | null) => void
@@ -82,10 +108,24 @@ function DeleteCollectionModal({
       })
 
       if (collections) {
-        // remove collection from collections.json
-        const newCollections = collections.filter(
-          (collectionInfo) => collectionInfo.slug !== collection.slug
+        const descendantSlugs = getDescendantCollectionSlugs(
+          collections,
+          collection.slug
         )
+        // remove collection from collections.json
+        const newCollections = collections
+          .filter(
+            (collectionInfo) =>
+              collectionInfo.slug !== collection.slug &&
+              (keepFiles || !descendantSlugs.has(collectionInfo.slug))
+          )
+          .map((collectionInfo) => ({
+            ...collectionInfo,
+            parent:
+              collectionInfo.parent === collection.slug
+                ? collection.parent
+                : collectionInfo.parent
+          }))
         capi.replaceFile(
           `${ostContent}/collections.json`,
           JSON.stringify(newCollections, null, 2)
@@ -98,11 +138,16 @@ function DeleteCollectionModal({
 
       // remove collection from metadata.json
       if (metadata) {
+        const descendantSlugs = collections
+          ? getDescendantCollectionSlugs(collections, collection.slug)
+          : new Set<string>()
         const m = metadata.metadata
         m.generated = new Date().toISOString()
         m.commit = hashFromUrl(metadata.commitUrl)
         const newMeta = (m.metadata ?? []).filter(
-          (post) => post.collection !== collection.slug
+          (post) =>
+            post.collection !== collection.slug &&
+            (keepFiles || !descendantSlugs.has(post.collection))
         )
         capi.replaceFile(
           `${ostContent}/metadata.json`,

--- a/packages/outstatic/src/client/pages/collections/_components/delete-collection-modal.tsx
+++ b/packages/outstatic/src/client/pages/collections/_components/delete-collection-modal.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle
 } from '@/components/ui/shadcn/dialog'
 import { Label } from '@/components/ui/shadcn/label'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { createCommitApi } from '@/utils/create-commit-api'
 import { createOutstaticCommitMessage } from '@/utils/commit-message'
 import { hashFromUrl } from '@/utils/hash-from-url'
@@ -43,14 +43,22 @@ function DeleteCollectionModal({
   const { canManageCollections } = usePermissions()
   const [deleting, setDeleting] = useState(false)
   const [keepFiles, setKeepFiles] = useState(false)
+  const [deleteChildren, setDeleteChildren] = useState(false)
   const fetchOid = useOid()
 
   const { refetch: refetchMetadata } = useGetMetadata({ enabled: false })
-  const { refetch: refetchCollections } = useCollections({
-    enabled: false
-  })
+  const { data: collectionsData, refetch: refetchCollections } =
+    useCollections()
 
   const mutation = useCreateCommit()
+  const descendantSlugs = useMemo(() => {
+    if (!collectionsData) {
+      return new Set<string>()
+    }
+
+    return getDescendantCollectionSlugs(collectionsData, collection.slug)
+  }, [collection.slug, collectionsData])
+  const hasChildCollections = descendantSlugs.size > 0
 
   useEffect(() => {
     if (!canManageCollections) {
@@ -86,35 +94,58 @@ function DeleteCollectionModal({
         branch: repoBranch
       })
 
-      if (collections) {
-        const newCollections = getCollectionsAfterDeletion(
-          collections,
-          collection,
-          keepFiles
+      const latestCollection =
+        collections.find(
+          (collectionInfo) => collectionInfo.slug === collection.slug
+        ) ?? collection
+      const latestDescendantSlugs = getDescendantCollectionSlugs(
+        collections,
+        collection.slug
+      )
+      const shouldDeleteChildren =
+        deleteChildren && latestDescendantSlugs.size > 0
+      const deletedCollections = collections.filter(
+        (collectionInfo) =>
+          collectionInfo.slug === collection.slug ||
+          (shouldDeleteChildren &&
+            latestDescendantSlugs.has(collectionInfo.slug))
+      )
+
+      if (
+        !deletedCollections.some(
+          (deletedCollection) =>
+            deletedCollection.slug === latestCollection.slug
         )
-        capi.replaceFile(
-          `${ostContent}/collections.json`,
-          JSON.stringify(newCollections, null, 2)
-        )
+      ) {
+        deletedCollections.push(latestCollection)
       }
 
+      const newCollections = getCollectionsAfterDeletion(
+        collections,
+        latestCollection,
+        shouldDeleteChildren
+      )
+      capi.replaceFile(
+        `${ostContent}/collections.json`,
+        JSON.stringify(newCollections, null, 2)
+      )
+
       if (!keepFiles) {
-        capi.removeFile(collection.path)
+        deletedCollections.forEach((deletedCollection) => {
+          capi.removeFile(deletedCollection.path)
+        })
       }
 
       // remove collection from metadata.json
       if (metadata) {
-        const descendantSlugs = collections
-          ? getDescendantCollectionSlugs(collections, collection.slug)
-          : new Set<string>()
         const m = metadata.metadata
         m.generated = new Date().toISOString()
         m.commit = hashFromUrl(metadata.commitUrl)
         const newMeta = getMetadataAfterCollectionDeletion(
           m.metadata ?? [],
           collection.slug,
-          descendantSlugs,
-          keepFiles
+          latestDescendantSlugs,
+          shouldDeleteChildren
         )
         capi.replaceFile(
           `${ostContent}/metadata.json`,
@@ -159,6 +190,25 @@ function DeleteCollectionModal({
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-6">
+          {hasChildCollections ? (
+            <div className="flex items-start space-x-2">
+              <Checkbox
+                id="delete-child-collections"
+                checked={deleteChildren}
+                onCheckedChange={() => setDeleteChildren(!deleteChildren)}
+                className="mt-0.5"
+              />
+              <Label
+                htmlFor="delete-child-collections"
+                className="leading-normal"
+              >
+                <div>
+                  Also delete child collections. When unchecked, child
+                  collections move up one level.
+                </div>
+              </Label>
+            </div>
+          ) : null}
           <div className="flex items-start space-x-2">
             <Checkbox
               id="detached-delete"
@@ -168,11 +218,9 @@ function DeleteCollectionModal({
             />
             <Label htmlFor="detached-delete" className="leading-normal ">
               <div>
-                Keep files in the repository. Only remove{' '}
-                <span className="inline-block font-bold first-letter:uppercase">
-                  {collection.title}
-                </span>{' '}
-                from the Outstatic&nbsp;Dashboard.
+                Keep files in the repository. Only remove the selected
+                collection{deleteChildren ? 's' : ''} from the
+                Outstatic&nbsp;Dashboard.
               </div>
             </Label>
           </div>

--- a/packages/outstatic/src/client/pages/collections/_components/new-collection-modal.tsx
+++ b/packages/outstatic/src/client/pages/collections/_components/new-collection-modal.tsx
@@ -54,30 +54,7 @@ import {
   DialogDescription
 } from '@/components/ui/shadcn/dialog'
 
-function normalizeCollectionPath(path: string) {
-  return path.replace(/^\/+|\/+$/g, '')
-}
-
-function findCollectionParent(
-  collections: CollectionType[],
-  collectionPath: string
-) {
-  const normalizedCollectionPath = normalizeCollectionPath(collectionPath)
-
-  return (
-    collections
-      .filter((collection) => {
-        const normalizedPath = normalizeCollectionPath(collection.path)
-
-        return (
-          normalizedPath !== '' &&
-          normalizedPath !== normalizedCollectionPath &&
-          normalizedCollectionPath.startsWith(`${normalizedPath}/`)
-        )
-      })
-      .sort((a, b) => b.path.length - a.path.length)[0]?.slug ?? null
-  )
-}
+import { findCollectionParent } from '@/utils/collections/collection-tree'
 
 export default function NewCollectionModal({
   open,

--- a/packages/outstatic/src/client/pages/collections/_components/new-collection-modal.tsx
+++ b/packages/outstatic/src/client/pages/collections/_components/new-collection-modal.tsx
@@ -17,7 +17,7 @@ import { Label } from '@/components/ui/shadcn/label'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/shadcn/radio-group'
 import { createCommitApi } from '@/utils/create-commit-api'
 import { createOutstaticCommitMessage } from '@/utils/commit-message'
-import { useCollections } from '@/utils/hooks/use-collections'
+import { CollectionType, useCollections } from '@/utils/hooks/use-collections'
 import { useCreateCommit } from '@/utils/hooks/use-create-commit'
 import { useGetDocuments } from '@/utils/hooks/use-get-documents'
 import useOid from '@/utils/hooks/use-oid'
@@ -53,6 +53,31 @@ import {
   DialogTitle,
   DialogDescription
 } from '@/components/ui/shadcn/dialog'
+
+function normalizeCollectionPath(path: string) {
+  return path.replace(/^\/+|\/+$/g, '')
+}
+
+function findCollectionParent(
+  collections: CollectionType[],
+  collectionPath: string
+) {
+  const normalizedCollectionPath = normalizeCollectionPath(collectionPath)
+
+  return (
+    collections
+      .filter((collection) => {
+        const normalizedPath = normalizeCollectionPath(collection.path)
+
+        return (
+          normalizedPath !== '' &&
+          normalizedPath !== normalizedCollectionPath &&
+          normalizedCollectionPath.startsWith(`${normalizedPath}/`)
+        )
+      })
+      .sort((a, b) => b.path.length - a.path.length)[0]?.slug ?? null
+  )
+}
 
 export default function NewCollectionModal({
   open,
@@ -160,7 +185,7 @@ export default function NewCollectionModal({
         title: name,
         slug,
         path: collectionPath,
-        children: []
+        parent: findCollectionParent(collections, collectionPath)
       })
 
       const schemaJson = {

--- a/packages/outstatic/src/client/pages/collections/collections.test.tsx
+++ b/packages/outstatic/src/client/pages/collections/collections.test.tsx
@@ -66,6 +66,20 @@ describe('Collections', () => {
     { slug: 'blog', title: 'Blog' },
     { slug: 'projects', title: 'Projects' }
   ]
+  const mockNestedCollections = [
+    {
+      slug: 'blog',
+      title: 'Blog',
+      path: 'outstatic/content/blog',
+      parent: null
+    },
+    {
+      slug: 'guides',
+      title: 'Guides',
+      path: 'outstatic/content/guides',
+      parent: 'blog'
+    }
+  ]
 
   beforeEach(() => {
     // Mock useOutstatic hook with session containing permissions
@@ -200,6 +214,28 @@ describe('Collections', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(
       screen.getByText(/are you sure you want to delete/i)
+    ).toBeInTheDocument()
+  })
+
+  it('shows the child collection deletion option for parent collections', () => {
+    ;(useCollections as jest.Mock).mockReturnValue({
+      isPending: false,
+      data: mockNestedCollections
+    })
+
+    render(
+      <TestWrapper>
+        <Collections />
+      </TestWrapper>
+    )
+
+    const deleteButtons = screen.getAllByRole('button', {
+      name: /delete content/i
+    })
+    fireEvent.click(deleteButtons[0])
+
+    expect(
+      screen.getByText(/also delete child collections/i)
     ).toBeInTheDocument()
   })
 

--- a/packages/outstatic/src/components/sidebar.tsx
+++ b/packages/outstatic/src/components/sidebar.tsx
@@ -17,7 +17,10 @@ import {
   Key,
   Users
 } from 'lucide-react'
-import { SidebarNavigation } from '@/components/ui/outstatic/sidebar'
+import {
+  buildParentChildRoutes,
+  SidebarNavigation
+} from '@/components/ui/outstatic/sidebar'
 
 import { useCollections } from '@/utils/hooks/use-collections'
 import { useSingletons } from '@/utils/hooks/use-singletons'
@@ -105,34 +108,38 @@ export const Sidebar = ({ additionalRoutes }: SidebarProps) => {
                     {
                       label: 'Collections',
                       collapsible: true,
-                      children: collections.map((collection) => ({
-                        label: collection.title,
-                        path: `${dashboardRoute}/${collection.slug}`,
-                        Icon: <Folder className={'w-4'} />,
-                        renderAction: (
-                          <TooltipProvider>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Link
-                                  href={`${dashboardRoute}/${collection.slug}/new`}
-                                  className="invisible group-hover/sub-menu-item:visible"
-                                  aria-label={`Create new item in collection ${collection.title}`}
-                                >
-                                  <Plus className="w-3 h-3 pointer-events-none" />
-                                </Link>
-                              </TooltipTrigger>
-                              <TooltipContent className="pointer-events-none">
-                                <p>
-                                  Create new{' '}
-                                  <span className="inline-block">
-                                    {singular(collection.title)}
-                                  </span>
-                                </p>
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        )
-                      }))
+                      children: buildParentChildRoutes(
+                        collections.map((collection) => ({
+                          label: collection.title,
+                          path: `${dashboardRoute}/${collection.slug}`,
+                          slug: collection.slug,
+                          parent: collection.parent,
+                          Icon: <Folder className={'w-4'} />,
+                          renderAction: (
+                            <TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Link
+                                    href={`${dashboardRoute}/${collection.slug}/new`}
+                                    className="invisible group-hover/sub-menu-item:visible"
+                                    aria-label={`Create new item in collection ${collection.title}`}
+                                  >
+                                    <Plus className="w-3 h-3 pointer-events-none" />
+                                  </Link>
+                                </TooltipTrigger>
+                                <TooltipContent className="pointer-events-none">
+                                  <p>
+                                    Create new{' '}
+                                    <span className="inline-block">
+                                      {singular(collection.title)}
+                                    </span>
+                                  </p>
+                                </TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
+                          )
+                        }))
+                      )
                     }
                   ]
                 : []),

--- a/packages/outstatic/src/components/sidebar.tsx
+++ b/packages/outstatic/src/components/sidebar.tsx
@@ -121,7 +121,6 @@ export const Sidebar = ({ additionalRoutes }: SidebarProps) => {
                                 <TooltipTrigger asChild>
                                   <Link
                                     href={`${dashboardRoute}/${collection.slug}/new`}
-                                    className="invisible group-hover/sub-menu-item:visible"
                                     aria-label={`Create new item in collection ${collection.title}`}
                                   >
                                     <Plus className="w-3 h-3 pointer-events-none" />

--- a/packages/outstatic/src/components/ui/outstatic/navigation-config.schema.ts
+++ b/packages/outstatic/src/components/ui/outstatic/navigation-config.schema.ts
@@ -12,15 +12,20 @@ const Divider = z.object({
 const RouteSubChild = z.object({
   label: z.string(),
   path: z.string(),
+  slug: z.string().optional(),
+  parent: z.string().nullable().optional(),
   Icon: z.custom<React.ReactNode>().optional(),
   action: z.custom<React.ReactNode>().optional(),
   end: RouteMatchingEnd,
-  renderAction: z.custom<React.ReactNode>().optional()
+  renderAction: z.custom<React.ReactNode>().optional(),
+  children: z.array(z.any()).default([]).optional()
 })
 
 const RouteChild = z.object({
   label: z.string(),
   path: z.string(),
+  slug: z.string().optional(),
+  parent: z.string().nullable().optional(),
   Icon: z.custom<React.ReactNode>().optional(),
   end: RouteMatchingEnd,
   action: z.custom<React.ReactNode>().optional(),

--- a/packages/outstatic/src/components/ui/outstatic/navigation-config.schema.ts
+++ b/packages/outstatic/src/components/ui/outstatic/navigation-config.schema.ts
@@ -9,7 +9,19 @@ const Divider = z.object({
   divider: z.literal(true)
 })
 
-const RouteSubChild = z.object({
+type RouteSubChildSchema = {
+  label: string
+  path: string
+  slug?: string
+  parent?: string | null
+  Icon?: React.ReactNode
+  action?: React.ReactNode
+  end?: z.infer<typeof RouteMatchingEnd>
+  renderAction?: React.ReactNode
+  children?: RouteSubChildSchema[]
+}
+
+const RouteSubChild: z.ZodType<RouteSubChildSchema> = z.object({
   label: z.string(),
   path: z.string(),
   slug: z.string().optional(),
@@ -18,7 +30,10 @@ const RouteSubChild = z.object({
   action: z.custom<React.ReactNode>().optional(),
   end: RouteMatchingEnd,
   renderAction: z.custom<React.ReactNode>().optional(),
-  children: z.array(z.any()).default([]).optional()
+  children: z
+    .array(z.lazy(() => RouteSubChild))
+    .default([])
+    .optional()
 })
 
 const RouteChild = z.object({

--- a/packages/outstatic/src/components/ui/outstatic/sidebar.tsx
+++ b/packages/outstatic/src/components/ui/outstatic/sidebar.tsx
@@ -43,6 +43,42 @@ import { useCollapsibleState } from '@/utils/hooks/use-collapsible-state'
 
 export type SidebarConfig = z.infer<typeof NavigationConfigSchema>
 
+export function buildParentChildRoutes<
+  T extends {
+    slug?: string
+    parent?: string | null
+    children?: T[]
+  }
+>(routes: T[]): T[] {
+  const clonedRoutes = routes.map((route) => ({
+    ...route,
+    children: route.children ? [...route.children] : []
+  })) as T[]
+  const routesBySlug = new Map<string, T>()
+  const rootRoutes: T[] = []
+
+  clonedRoutes.forEach((route) => {
+    if (route.slug) {
+      routesBySlug.set(route.slug, route)
+    }
+  })
+
+  clonedRoutes.forEach((route) => {
+    if (route.parent) {
+      const parentRoute = routesBySlug.get(route.parent)
+
+      if (parentRoute && parentRoute !== route) {
+        parentRoute.children = [...(parentRoute.children ?? []), route]
+        return
+      }
+    }
+
+    rootRoutes.push(route)
+  })
+
+  return rootRoutes
+}
+
 function isExactRoute(path: string, currentPath: string) {
   const normalizedPath = (path.split('?')[0] || '').replace(/\/+$/, '') || '/'
   const normalizedCurrentPath = currentPath.replace(/\/+$/, '') || '/'
@@ -74,8 +110,92 @@ function isRouteChild(child: unknown): child is {
   Icon?: React.ReactNode
   end?: boolean | ((input: string) => boolean)
   renderAction?: React.ReactNode
+  children?: unknown[]
 } {
   return typeof child === 'object' && child !== null && 'path' in child
+}
+
+function RouteSubChildItem({
+  child,
+  currentPath,
+  open,
+  parentKey
+}: {
+  child: RouteSubChildType & { children?: unknown[] }
+  currentPath: string
+  open: boolean
+  parentKey: string
+}) {
+  const isActive = isRouteActive(child.path, currentPath, child.end)
+  const isCurrentRoute = isExactRoute(child.path, currentPath)
+  const children = Array.isArray(child.children) ? child.children : []
+
+  const linkClassName = cn('flex items-center', {
+    'mx-auto w-full gap-0! [&>svg]:flex-1': !open
+  })
+
+  const spanClassName = cn('w-auto transition-opacity duration-300', {
+    'w-0 opacity-0': !open
+  })
+
+  return (
+    <SidebarMenuSubItem className="group/sub-menu-item">
+      <SidebarMenuSubButton isActive={isActive} asChild>
+        <Link
+          className={cn(linkClassName, {
+            'pointer-events-none': isCurrentRoute
+          })}
+          href={child.path}
+        >
+          {child.Icon}
+          <span className={spanClassName}>{child.label}</span>
+        </Link>
+      </SidebarMenuSubButton>
+      <If condition={child.renderAction}>
+        <SidebarMenuAction>{child.renderAction}</SidebarMenuAction>
+      </If>
+      {children.length > 0 ? (
+        <SidebarMenuSub
+          className={cn({
+            'mx-0 px-1.5': !open
+          })}
+        >
+          {children.map((nestedChild, nestedChildIndex) => {
+            if (isRouteGroup(nestedChild)) {
+              return (
+                <SubRouteGroup
+                  key={`${parentKey}-group-${nestedChildIndex}`}
+                  group={nestedChild}
+                  currentPath={currentPath}
+                  open={open}
+                  depth={1}
+                  parentKey={parentKey}
+                />
+              )
+            }
+
+            if (isRouteChild(nestedChild)) {
+              return (
+                <RouteSubChildItem
+                  key={`${parentKey}-${nestedChild.path}`}
+                  child={
+                    nestedChild as RouteSubChildType & {
+                      children?: unknown[]
+                    }
+                  }
+                  currentPath={currentPath}
+                  open={open}
+                  parentKey={`${parentKey}-${nestedChild.path}`}
+                />
+              )
+            }
+
+            return null
+          })}
+        </SidebarMenuSub>
+      ) : null}
+    </SidebarMenuSubItem>
+  )
 }
 
 // Recursive component for rendering sub-RouteGroups
@@ -193,27 +313,16 @@ function SubRouteGroup({
 
               // Render RouteChild items
               if (isRouteChild(child)) {
-                const isActive = isRouteActive(
-                  child.path,
-                  currentPath,
-                  child.end
-                )
-                const isCurrentRoute = isExactRoute(child.path, currentPath)
-
                 return (
-                  <SidebarMenuSubItem key={child.path}>
-                    <SidebarMenuSubButton isActive={isActive} asChild>
-                      <Link
-                        className={cn(linkClassName, {
-                          'pointer-events-none': isCurrentRoute
-                        })}
-                        href={child.path}
-                      >
-                        {child.Icon}
-                        <span className={spanClassName}>{child.label}</span>
-                      </Link>
-                    </SidebarMenuSubButton>
-                  </SidebarMenuSubItem>
+                  <RouteSubChildItem
+                    key={child.path}
+                    child={
+                      child as RouteSubChildType & { children?: unknown[] }
+                    }
+                    currentPath={currentPath}
+                    open={open}
+                    parentKey={`${parentKey}-${child.path}`}
+                  />
                 )
               }
 
@@ -497,69 +606,18 @@ export function SidebarNavigation({
                                               )
                                             }
 
-                                            const isActive = isRouteActive(
-                                              subChild.path,
-                                              currentPath,
-                                              subChild.end
-                                            )
-                                            const isCurrentRoute = isExactRoute(
-                                              subChild.path,
-                                              currentPath
-                                            )
-
-                                            const linkClassName = cn(
-                                              'flex items-center',
-                                              {
-                                                'mx-auto w-full gap-0! [&>svg]:flex-1':
-                                                  !open
-                                              }
-                                            )
-
-                                            const spanClassName = cn(
-                                              'w-auto transition-opacity duration-300',
-                                              {
-                                                'w-0 opacity-0': !open
-                                              }
-                                            )
-
                                             return (
-                                              <SidebarMenuSubItem
+                                              <RouteSubChildItem
                                                 key={subChild.path}
-                                                className="group/sub-menu-item"
-                                              >
-                                                <SidebarMenuSubButton
-                                                  isActive={isActive}
-                                                  asChild
-                                                >
-                                                  <Link
-                                                    className={cn(
-                                                      linkClassName,
-                                                      {
-                                                        'pointer-events-none':
-                                                          isCurrentRoute
-                                                      }
-                                                    )}
-                                                    href={subChild.path}
-                                                  >
-                                                    {subChild.Icon}
-
-                                                    <span
-                                                      className={spanClassName}
-                                                    >
-                                                      {subChild.label}
-                                                    </span>
-                                                  </Link>
-                                                </SidebarMenuSubButton>
-                                                <If
-                                                  condition={
-                                                    subChild.renderAction
+                                                child={
+                                                  subChild as RouteSubChildType & {
+                                                    children?: unknown[]
                                                   }
-                                                >
-                                                  <SidebarMenuAction>
-                                                    {subChild.renderAction}
-                                                  </SidebarMenuAction>
-                                                </If>
-                                              </SidebarMenuSubItem>
+                                                }
+                                                currentPath={currentPath}
+                                                open={open}
+                                                parentKey={`${childKey}-${subChild.path}`}
+                                              />
                                             )
                                           }
                                         )}

--- a/packages/outstatic/src/components/ui/outstatic/sidebar.tsx
+++ b/packages/outstatic/src/components/ui/outstatic/sidebar.tsx
@@ -43,41 +43,7 @@ import { useCollapsibleState } from '@/utils/hooks/use-collapsible-state'
 
 export type SidebarConfig = z.infer<typeof NavigationConfigSchema>
 
-export function buildParentChildRoutes<
-  T extends {
-    slug?: string
-    parent?: string | null
-    children?: T[]
-  }
->(routes: T[]): T[] {
-  const clonedRoutes = routes.map((route) => ({
-    ...route,
-    children: route.children ? [...route.children] : []
-  })) as T[]
-  const routesBySlug = new Map<string, T>()
-  const rootRoutes: T[] = []
-
-  clonedRoutes.forEach((route) => {
-    if (route.slug) {
-      routesBySlug.set(route.slug, route)
-    }
-  })
-
-  clonedRoutes.forEach((route) => {
-    if (route.parent) {
-      const parentRoute = routesBySlug.get(route.parent)
-
-      if (parentRoute && parentRoute !== route) {
-        parentRoute.children = [...(parentRoute.children ?? []), route]
-        return
-      }
-    }
-
-    rootRoutes.push(route)
-  })
-
-  return rootRoutes
-}
+export { buildParentChildRoutes } from '@/utils/collections/collection-tree'
 
 function isExactRoute(path: string, currentPath: string) {
   const normalizedPath = (path.split('?')[0] || '').replace(/\/+$/, '') || '/'

--- a/packages/outstatic/src/components/ui/outstatic/sidebar.tsx
+++ b/packages/outstatic/src/components/ui/outstatic/sidebar.tsx
@@ -134,13 +134,17 @@ function RouteSubChildItem({
     'mx-auto w-full gap-0! [&>svg]:flex-1': !open
   })
 
-  const spanClassName = cn('w-auto transition-opacity duration-300', {
+  const spanClassName = cn('w-auto transition-opacity duration-300 pr-2.5', {
     'w-0 opacity-0': !open
   })
 
   return (
-    <SidebarMenuSubItem className="group/sub-menu-item">
-      <SidebarMenuSubButton isActive={isActive} asChild>
+    <SidebarMenuSubItem>
+      <SidebarMenuSubButton
+        isActive={isActive}
+        className="peer/sub-menu-button"
+        asChild
+      >
         <Link
           className={cn(linkClassName, {
             'pointer-events-none': isCurrentRoute
@@ -152,13 +156,18 @@ function RouteSubChildItem({
         </Link>
       </SidebarMenuSubButton>
       <If condition={child.renderAction}>
-        <SidebarMenuAction>{child.renderAction}</SidebarMenuAction>
+        <SidebarMenuAction className="opacity-0 hover:opacity-100 focus-visible:opacity-100 peer-hover/sub-menu-button:opacity-100 peer-focus-visible/sub-menu-button:opacity-100 data-[state=open]:opacity-100">
+          {child.renderAction}
+        </SidebarMenuAction>
       </If>
       {children.length > 0 ? (
         <SidebarMenuSub
-          className={cn({
-            'mx-0 px-1.5': !open
-          })}
+          className={cn(
+            {
+              'mx-0 px-1.5': !open
+            },
+            'mr-0 pr-0'
+          )}
         >
           {children.map((nestedChild, nestedChildIndex) => {
             if (isRouteGroup(nestedChild)) {
@@ -473,10 +482,7 @@ export function SidebarNavigation({
                             if ('collapsible' in child && child.collapsible) {
                               return (
                                 <CollapsibleTrigger asChild>
-                                  <SidebarMenuButton
-                                    tooltip={child.label}
-                                    className="group/sub-menu-item"
-                                  >
+                                  <SidebarMenuButton tooltip={child.label}>
                                     <div
                                       className={cn('flex items-center gap-2', {
                                         'mx-auto w-full gap-0 [&>svg]:flex-1 [&>svg]:shrink-0':
@@ -581,9 +587,12 @@ export function SidebarNavigation({
                                   <If condition={child.children}>
                                     {(children) => (
                                       <SidebarMenuSub
-                                        className={cn({
-                                          'mx-0 px-1.5': !open
-                                        })}
+                                        className={cn(
+                                          {
+                                            'mx-0 px-1.5': !open
+                                          },
+                                          'mr-0 pr-0'
+                                        )}
                                       >
                                         {children.map(
                                           (

--- a/packages/outstatic/src/utils/collections/__tests__/collection-tree.test.ts
+++ b/packages/outstatic/src/utils/collections/__tests__/collection-tree.test.ts
@@ -1,0 +1,308 @@
+import {
+  buildParentChildRoutes,
+  findCollectionParent,
+  getCollectionsAfterDeletion,
+  getDescendantCollectionSlugs,
+  getMetadataAfterCollectionDeletion,
+  normalizeCollectionPath,
+  normalizeCollections,
+  type CollectionType
+} from '../collection-tree'
+
+const collection = (
+  slug: string,
+  path: string,
+  parent: string | null = null,
+  title = slug
+): CollectionType => ({
+  title,
+  slug,
+  path,
+  parent
+})
+
+describe('normalizeCollectionPath', () => {
+  it('strips leading and trailing slashes', () => {
+    expect(normalizeCollectionPath('/outstatic/content/posts/')).toBe(
+      'outstatic/content/posts'
+    )
+  })
+
+  it('returns an empty string for slash-only paths', () => {
+    expect(normalizeCollectionPath('///')).toBe('')
+  })
+
+  it('leaves already-normalized paths unchanged', () => {
+    expect(normalizeCollectionPath('outstatic/content/posts/guides')).toBe(
+      'outstatic/content/posts/guides'
+    )
+  })
+})
+
+describe('findCollectionParent', () => {
+  const collections = [
+    collection('posts', 'outstatic/content/posts'),
+    collection('guides', 'outstatic/content/posts/guides', 'posts'),
+    collection('projects', 'outstatic/content/projects')
+  ]
+
+  it('returns null when no collection path is a prefix', () => {
+    expect(
+      findCollectionParent(collections, 'outstatic/content/news')
+    ).toBeNull()
+  })
+
+  it('returns the longest matching prefix parent', () => {
+    expect(
+      findCollectionParent(
+        collections,
+        'outstatic/content/posts/guides/chapters'
+      )
+    ).toBe('guides')
+  })
+
+  it('ignores the collection itself and empty paths', () => {
+    expect(
+      findCollectionParent(
+        [...collections, collection('empty', '', null)],
+        'outstatic/content/posts/new-post'
+      )
+    ).toBe('posts')
+  })
+
+  it('normalizes slash-padded paths before matching', () => {
+    expect(
+      findCollectionParent(collections, '/outstatic/content/posts/guides/')
+    ).toBe('posts')
+  })
+})
+
+describe('getDescendantCollectionSlugs', () => {
+  const collections = [
+    collection('posts', 'outstatic/content/posts'),
+    collection('guides', 'outstatic/content/posts/guides', 'posts'),
+    collection('chapters', 'outstatic/content/posts/guides/chapters', 'guides'),
+    collection('projects', 'outstatic/content/projects')
+  ]
+
+  it('returns an empty set when there are no descendants', () => {
+    expect(getDescendantCollectionSlugs(collections, 'projects')).toEqual(
+      new Set()
+    )
+  })
+
+  it('collects direct and nested descendants', () => {
+    expect(getDescendantCollectionSlugs(collections, 'posts')).toEqual(
+      new Set(['guides', 'chapters'])
+    )
+  })
+
+  it('collects descendants from an intermediate node', () => {
+    expect(getDescendantCollectionSlugs(collections, 'guides')).toEqual(
+      new Set(['chapters'])
+    )
+  })
+})
+
+describe('normalizeCollections', () => {
+  it('flattens nested children and assigns parent slugs', () => {
+    expect(
+      normalizeCollections([
+        {
+          title: 'Posts',
+          slug: 'posts',
+          path: 'outstatic/content/posts',
+          children: [
+            {
+              title: 'Guides',
+              slug: 'guides',
+              path: 'outstatic/content/posts/guides',
+              children: []
+            }
+          ]
+        }
+      ])
+    ).toEqual([
+      collection('posts', 'outstatic/content/posts', null, 'Posts'),
+      collection('guides', 'outstatic/content/posts/guides', 'posts', 'Guides')
+    ])
+  })
+
+  it('prefers an explicit parent on nested items', () => {
+    expect(
+      normalizeCollections([
+        {
+          title: 'Posts',
+          slug: 'posts',
+          path: 'outstatic/content/posts',
+          children: [
+            {
+              title: 'Guides',
+              slug: 'guides',
+              path: 'outstatic/content/posts/guides',
+              parent: 'projects',
+              children: []
+            }
+          ]
+        }
+      ])
+    ).toEqual([
+      collection('posts', 'outstatic/content/posts', null, 'Posts'),
+      collection(
+        'guides',
+        'outstatic/content/posts/guides',
+        'projects',
+        'Guides'
+      )
+    ])
+  })
+
+  it('returns an empty array for empty input', () => {
+    expect(normalizeCollections()).toEqual([])
+  })
+})
+
+describe('getCollectionsAfterDeletion', () => {
+  const collections = [
+    collection('posts', 'outstatic/content/posts'),
+    collection('guides', 'outstatic/content/posts/guides', 'posts'),
+    collection('chapters', 'outstatic/content/posts/guides/chapters', 'guides'),
+    collection('projects', 'outstatic/content/projects')
+  ]
+
+  it('removes only the target collection when keepFiles is true', () => {
+    expect(
+      getCollectionsAfterDeletion(collections, collections[0], true)
+    ).toEqual([
+      collection('guides', 'outstatic/content/posts/guides', null),
+      collection(
+        'chapters',
+        'outstatic/content/posts/guides/chapters',
+        'guides'
+      ),
+      collection('projects', 'outstatic/content/projects')
+    ])
+  })
+
+  it('removes the target and all descendants when keepFiles is false', () => {
+    expect(
+      getCollectionsAfterDeletion(collections, collections[0], false)
+    ).toEqual([collection('projects', 'outstatic/content/projects')])
+  })
+
+  it('re-parents direct children to the deleted collection parent', () => {
+    const nestedCollections = [
+      collection('blog', 'outstatic/content/blog'),
+      collection('posts', 'outstatic/content/blog/posts', 'blog'),
+      collection('drafts', 'outstatic/content/blog/posts/drafts', 'posts')
+    ]
+
+    expect(
+      getCollectionsAfterDeletion(nestedCollections, nestedCollections[1], true)
+    ).toEqual([
+      collection('blog', 'outstatic/content/blog'),
+      collection('drafts', 'outstatic/content/blog/posts/drafts', 'blog')
+    ])
+  })
+
+  it('removes a leaf collection without affecting siblings', () => {
+    expect(
+      getCollectionsAfterDeletion(collections, collections[3], false)
+    ).toEqual(collections.slice(0, 3))
+  })
+})
+
+describe('getMetadataAfterCollectionDeletion', () => {
+  const metadata = [
+    { collection: 'posts', slug: 'post-1' },
+    { collection: 'guides', slug: 'guide-1' },
+    { collection: 'chapters', slug: 'chapter-1' },
+    { collection: 'projects', slug: 'project-1' }
+  ]
+
+  it('keeps descendant metadata when keepFiles is true', () => {
+    expect(
+      getMetadataAfterCollectionDeletion(
+        metadata,
+        'posts',
+        new Set(['guides', 'chapters']),
+        true
+      )
+    ).toEqual([
+      { collection: 'guides', slug: 'guide-1' },
+      { collection: 'chapters', slug: 'chapter-1' },
+      { collection: 'projects', slug: 'project-1' }
+    ])
+  })
+
+  it('removes descendant metadata when keepFiles is false', () => {
+    expect(
+      getMetadataAfterCollectionDeletion(
+        metadata,
+        'posts',
+        new Set(['guides', 'chapters']),
+        false
+      )
+    ).toEqual([{ collection: 'projects', slug: 'project-1' }])
+  })
+})
+
+describe('buildParentChildRoutes', () => {
+  type Route = {
+    label: string
+    slug?: string
+    parent?: string | null
+    children?: Route[]
+  }
+
+  const routes: Route[] = [
+    { label: 'Posts', slug: 'posts', parent: null },
+    { label: 'Guides', slug: 'guides', parent: 'posts' },
+    { label: 'Projects', slug: 'projects', parent: null },
+    { label: 'Orphan', slug: 'orphan', parent: 'missing' }
+  ]
+
+  it('nests routes under their parent slug', () => {
+    const result = buildParentChildRoutes(routes)
+
+    expect(result).toHaveLength(3)
+    expect(result.find((route) => route.slug === 'posts')?.children).toEqual([
+      { label: 'Guides', slug: 'guides', parent: 'posts', children: [] }
+    ])
+  })
+
+  it('places routes with unknown parents at the root', () => {
+    const result = buildParentChildRoutes(routes)
+
+    expect(result.some((route) => route.slug === 'orphan')).toBe(true)
+  })
+
+  it('preserves existing children and appends parent-linked routes', () => {
+    const result = buildParentChildRoutes([
+      {
+        label: 'Posts',
+        slug: 'posts',
+        parent: null,
+        children: [{ label: 'Pinned', slug: 'pinned', parent: 'posts' }]
+      },
+      { label: 'Guides', slug: 'guides', parent: 'posts' }
+    ])
+
+    expect(result[0].children).toEqual([
+      { label: 'Pinned', slug: 'pinned', parent: 'posts' },
+      { label: 'Guides', slug: 'guides', parent: 'posts', children: [] }
+    ])
+  })
+
+  it('does not mutate the input routes', () => {
+    const input: Route[] = [
+      { label: 'Posts', slug: 'posts', parent: null },
+      { label: 'Guides', slug: 'guides', parent: 'posts' }
+    ]
+
+    buildParentChildRoutes(input)
+
+    expect(input[0].children).toBeUndefined()
+    expect(input).toHaveLength(2)
+  })
+})

--- a/packages/outstatic/src/utils/collections/__tests__/collection-tree.test.ts
+++ b/packages/outstatic/src/utils/collections/__tests__/collection-tree.test.ts
@@ -219,9 +219,9 @@ describe('getCollectionsAfterDeletion', () => {
     collection('projects', 'outstatic/content/projects')
   ]
 
-  it('removes only the target collection when keepFiles is true', () => {
+  it('removes only the target collection when deleteChildren is false', () => {
     expect(
-      getCollectionsAfterDeletion(collections, collections[0], true)
+      getCollectionsAfterDeletion(collections, collections[0], false)
     ).toEqual([
       collection('guides', 'outstatic/content/posts/guides', null),
       collection(
@@ -233,9 +233,9 @@ describe('getCollectionsAfterDeletion', () => {
     ])
   })
 
-  it('removes the target and all descendants when keepFiles is false', () => {
+  it('removes the target and all descendants when deleteChildren is true', () => {
     expect(
-      getCollectionsAfterDeletion(collections, collections[0], false)
+      getCollectionsAfterDeletion(collections, collections[0], true)
     ).toEqual([collection('projects', 'outstatic/content/projects')])
   })
 
@@ -247,7 +247,11 @@ describe('getCollectionsAfterDeletion', () => {
     ]
 
     expect(
-      getCollectionsAfterDeletion(nestedCollections, nestedCollections[1], true)
+      getCollectionsAfterDeletion(
+        nestedCollections,
+        nestedCollections[1],
+        false
+      )
     ).toEqual([
       collection('blog', 'outstatic/content/blog'),
       collection('drafts', 'outstatic/content/blog/posts/drafts', 'blog')
@@ -269,13 +273,13 @@ describe('getMetadataAfterCollectionDeletion', () => {
     { collection: 'projects', slug: 'project-1' }
   ]
 
-  it('keeps descendant metadata when keepFiles is true', () => {
+  it('keeps descendant metadata when deleteChildren is false', () => {
     expect(
       getMetadataAfterCollectionDeletion(
         metadata,
         'posts',
         new Set(['guides', 'chapters']),
-        true
+        false
       )
     ).toEqual([
       { collection: 'guides', slug: 'guide-1' },
@@ -284,13 +288,13 @@ describe('getMetadataAfterCollectionDeletion', () => {
     ])
   })
 
-  it('removes descendant metadata when keepFiles is false', () => {
+  it('removes descendant metadata when deleteChildren is true', () => {
     expect(
       getMetadataAfterCollectionDeletion(
         metadata,
         'posts',
         new Set(['guides', 'chapters']),
-        false
+        true
       )
     ).toEqual([{ collection: 'projects', slug: 'project-1' }])
   })

--- a/packages/outstatic/src/utils/collections/__tests__/collection-tree.test.ts
+++ b/packages/outstatic/src/utils/collections/__tests__/collection-tree.test.ts
@@ -358,4 +358,18 @@ describe('buildParentChildRoutes', () => {
     expect(input[0].children).toBeUndefined()
     expect(input).toHaveLength(2)
   })
+
+  it('falls back to root for routes caught in a parent cycle', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = buildParentChildRoutes([
+      { label: 'A', slug: 'a', parent: 'b' },
+      { label: 'B', slug: 'b', parent: 'a' }
+    ])
+
+    expect(result.map((route) => route.slug).sort()).toEqual(['a', 'b'])
+    expect(warn).toHaveBeenCalledTimes(2)
+
+    warn.mockRestore()
+  })
 })

--- a/packages/outstatic/src/utils/collections/__tests__/collection-tree.test.ts
+++ b/packages/outstatic/src/utils/collections/__tests__/collection-tree.test.ts
@@ -3,9 +3,12 @@ import {
   findCollectionParent,
   getCollectionsAfterDeletion,
   getDescendantCollectionSlugs,
+  getInvalidParentCollectionSlugs,
   getMetadataAfterCollectionDeletion,
+  getValidParentCollectionOptions,
   normalizeCollectionPath,
   normalizeCollections,
+  updateCollectionParent,
   type CollectionType
 } from '../collection-tree'
 
@@ -74,6 +77,52 @@ describe('findCollectionParent', () => {
     expect(
       findCollectionParent(collections, '/outstatic/content/posts/guides/')
     ).toBe('posts')
+  })
+})
+
+describe('getInvalidParentCollectionSlugs', () => {
+  const collections = [
+    collection('posts', 'outstatic/content/posts'),
+    collection('guides', 'outstatic/content/posts/guides', 'posts'),
+    collection('chapters', 'outstatic/content/posts/guides/chapters', 'guides'),
+    collection('projects', 'outstatic/content/projects')
+  ]
+
+  it('includes the collection and all descendants', () => {
+    expect(getInvalidParentCollectionSlugs(collections, 'posts')).toEqual(
+      new Set(['posts', 'guides', 'chapters'])
+    )
+  })
+})
+
+describe('getValidParentCollectionOptions', () => {
+  const collections = [
+    collection('posts', 'outstatic/content/posts'),
+    collection('guides', 'outstatic/content/posts/guides', 'posts'),
+    collection('chapters', 'outstatic/content/posts/guides/chapters', 'guides'),
+    collection('projects', 'outstatic/content/projects')
+  ]
+
+  it('excludes the collection and its descendants', () => {
+    expect(
+      getValidParentCollectionOptions(collections, 'guides').map(
+        (collectionInfo) => collectionInfo.slug
+      )
+    ).toEqual(['posts', 'projects'])
+  })
+})
+
+describe('updateCollectionParent', () => {
+  const collections = [
+    collection('posts', 'outstatic/content/posts'),
+    collection('guides', 'outstatic/content/posts/guides', 'posts')
+  ]
+
+  it('updates the parent slug for the target collection', () => {
+    expect(updateCollectionParent(collections, 'guides', null)).toEqual([
+      collection('posts', 'outstatic/content/posts'),
+      collection('guides', 'outstatic/content/posts/guides', null)
+    ])
   })
 })
 

--- a/packages/outstatic/src/utils/collections/collection-tree.ts
+++ b/packages/outstatic/src/utils/collections/collection-tree.ts
@@ -183,13 +183,34 @@ export function buildParentChildRoutes<
     }
   })
 
+  const hasCycle = (route: T) => {
+    const visited = new Set<string>()
+    let current: T | undefined = route
+
+    while (current?.parent) {
+      if (visited.has(current.parent)) {
+        return true
+      }
+      visited.add(current.parent)
+      current = routesBySlug.get(current.parent)
+    }
+
+    return false
+  }
+
   clonedRoutes.forEach((route) => {
     if (route.parent) {
       const parentRoute = routesBySlug.get(route.parent)
 
-      if (parentRoute && parentRoute !== route) {
-        parentRoute.children = [...(parentRoute.children ?? []), route]
-        return
+      if (parentRoute) {
+        if (parentRoute !== route && !hasCycle(route)) {
+          parentRoute.children = [...(parentRoute.children ?? []), route]
+          return
+        }
+
+        console.warn(
+          `Collection "${route.slug}" has a circular parent reference and will be rendered at the root.`
+        )
       }
     }
 

--- a/packages/outstatic/src/utils/collections/collection-tree.ts
+++ b/packages/outstatic/src/utils/collections/collection-tree.ts
@@ -33,7 +33,11 @@ export function findCollectionParent(
           normalizedCollectionPath.startsWith(`${normalizedPath}/`)
         )
       })
-      .sort((a, b) => b.path.length - a.path.length)[0]?.slug ?? null
+      .sort(
+        (a, b) =>
+          normalizeCollectionPath(b.path).length -
+          normalizeCollectionPath(a.path).length
+      )[0]?.slug ?? null
   )
 }
 
@@ -76,23 +80,32 @@ export function getDescendantCollectionSlugs(
   collections: CollectionType[],
   parentSlug: string
 ) {
+  const childrenByParent = new Map<string, string[]>()
+
+  collections.forEach((collection) => {
+    if (!collection.parent) {
+      return
+    }
+    const siblings = childrenByParent.get(collection.parent) ?? []
+    siblings.push(collection.slug)
+    childrenByParent.set(collection.parent, siblings)
+  })
+
   const descendantSlugs = new Set<string>()
-  let foundDescendant = true
+  const queue = [...(childrenByParent.get(parentSlug) ?? [])]
 
-  while (foundDescendant) {
-    foundDescendant = false
+  while (queue.length > 0) {
+    const slug = queue.shift() as string
 
-    collections.forEach((collection) => {
-      if (
-        collection.parent &&
-        (collection.parent === parentSlug ||
-          descendantSlugs.has(collection.parent)) &&
-        !descendantSlugs.has(collection.slug)
-      ) {
-        descendantSlugs.add(collection.slug)
-        foundDescendant = true
-      }
-    })
+    if (descendantSlugs.has(slug)) {
+      continue
+    }
+
+    descendantSlugs.add(slug)
+    const children = childrenByParent.get(slug)
+    if (children) {
+      queue.push(...children)
+    }
   }
 
   return descendantSlugs

--- a/packages/outstatic/src/utils/collections/collection-tree.ts
+++ b/packages/outstatic/src/utils/collections/collection-tree.ts
@@ -151,11 +151,16 @@ export function getMetadataAfterCollectionDeletion(
   descendantSlugs: Set<string>,
   keepFiles: boolean
 ): MetadataType {
-  return metadata.filter(
-    (post) =>
+  return metadata.filter((post) => {
+    const isDescendantCollection =
+      typeof post.collection === 'string' &&
+      descendantSlugs.has(post.collection)
+
+    return (
       post.collection !== collectionSlug &&
-      (keepFiles || !descendantSlugs.has(post.collection))
-  )
+      (keepFiles || !isDescendantCollection)
+    )
+  })
 }
 
 export function buildParentChildRoutes<

--- a/packages/outstatic/src/utils/collections/collection-tree.ts
+++ b/packages/outstatic/src/utils/collections/collection-tree.ts
@@ -123,7 +123,7 @@ export function normalizeCollections(
 export function getCollectionsAfterDeletion(
   collections: CollectionType[],
   collection: CollectionType,
-  keepFiles: boolean
+  deleteChildren: boolean
 ): CollectionType[] {
   const descendantSlugs = getDescendantCollectionSlugs(
     collections,
@@ -134,7 +134,7 @@ export function getCollectionsAfterDeletion(
     .filter(
       (collectionInfo) =>
         collectionInfo.slug !== collection.slug &&
-        (keepFiles || !descendantSlugs.has(collectionInfo.slug))
+        (!deleteChildren || !descendantSlugs.has(collectionInfo.slug))
     )
     .map((collectionInfo) => ({
       ...collectionInfo,
@@ -149,7 +149,7 @@ export function getMetadataAfterCollectionDeletion(
   metadata: MetadataType,
   collectionSlug: string,
   descendantSlugs: Set<string>,
-  keepFiles: boolean
+  deleteChildren: boolean
 ): MetadataType {
   return metadata.filter((post) => {
     const isDescendantCollection =
@@ -158,7 +158,7 @@ export function getMetadataAfterCollectionDeletion(
 
     return (
       post.collection !== collectionSlug &&
-      (keepFiles || !isDescendantCollection)
+      (!deleteChildren || !isDescendantCollection)
     )
   })
 }

--- a/packages/outstatic/src/utils/collections/collection-tree.ts
+++ b/packages/outstatic/src/utils/collections/collection-tree.ts
@@ -1,0 +1,160 @@
+import type { MetadataType } from '@/utils/metadata/types'
+
+export type CollectionType = {
+  title: string
+  slug: string
+  path: string
+  parent: string | null
+}
+
+type LegacyCollectionType = Omit<CollectionType, 'parent'> & {
+  parent?: string | null
+  children?: LegacyCollectionType[]
+}
+
+export function normalizeCollectionPath(path: string) {
+  return path.replace(/^\/+|\/+$/g, '')
+}
+
+export function findCollectionParent(
+  collections: CollectionType[],
+  collectionPath: string
+) {
+  const normalizedCollectionPath = normalizeCollectionPath(collectionPath)
+
+  return (
+    collections
+      .filter((collection) => {
+        const normalizedPath = normalizeCollectionPath(collection.path)
+
+        return (
+          normalizedPath !== '' &&
+          normalizedPath !== normalizedCollectionPath &&
+          normalizedCollectionPath.startsWith(`${normalizedPath}/`)
+        )
+      })
+      .sort((a, b) => b.path.length - a.path.length)[0]?.slug ?? null
+  )
+}
+
+export function getDescendantCollectionSlugs(
+  collections: CollectionType[],
+  parentSlug: string
+) {
+  const descendantSlugs = new Set<string>()
+  let foundDescendant = true
+
+  while (foundDescendant) {
+    foundDescendant = false
+
+    collections.forEach((collection) => {
+      if (
+        collection.parent &&
+        (collection.parent === parentSlug ||
+          descendantSlugs.has(collection.parent)) &&
+        !descendantSlugs.has(collection.slug)
+      ) {
+        descendantSlugs.add(collection.slug)
+        foundDescendant = true
+      }
+    })
+  }
+
+  return descendantSlugs
+}
+
+export function normalizeCollections(
+  collections: LegacyCollectionType[] = [],
+  parent: string | null = null
+): CollectionType[] {
+  return collections.flatMap((collection) => {
+    const {
+      children = [],
+      parent: collectionParent,
+      ...collectionData
+    } = collection
+    const normalizedCollection = {
+      ...collectionData,
+      parent: collectionParent ?? parent
+    }
+
+    return [
+      normalizedCollection,
+      ...normalizeCollections(children, normalizedCollection.slug)
+    ]
+  })
+}
+
+export function getCollectionsAfterDeletion(
+  collections: CollectionType[],
+  collection: CollectionType,
+  keepFiles: boolean
+): CollectionType[] {
+  const descendantSlugs = getDescendantCollectionSlugs(
+    collections,
+    collection.slug
+  )
+
+  return collections
+    .filter(
+      (collectionInfo) =>
+        collectionInfo.slug !== collection.slug &&
+        (keepFiles || !descendantSlugs.has(collectionInfo.slug))
+    )
+    .map((collectionInfo) => ({
+      ...collectionInfo,
+      parent:
+        collectionInfo.parent === collection.slug
+          ? collection.parent
+          : collectionInfo.parent
+    }))
+}
+
+export function getMetadataAfterCollectionDeletion(
+  metadata: MetadataType,
+  collectionSlug: string,
+  descendantSlugs: Set<string>,
+  keepFiles: boolean
+): MetadataType {
+  return metadata.filter(
+    (post) =>
+      post.collection !== collectionSlug &&
+      (keepFiles || !descendantSlugs.has(post.collection))
+  )
+}
+
+export function buildParentChildRoutes<
+  T extends {
+    slug?: string
+    parent?: string | null
+    children?: T[]
+  }
+>(routes: T[]): T[] {
+  const clonedRoutes = routes.map((route) => ({
+    ...route,
+    children: route.children ? [...route.children] : []
+  })) as T[]
+  const routesBySlug = new Map<string, T>()
+  const rootRoutes: T[] = []
+
+  clonedRoutes.forEach((route) => {
+    if (route.slug) {
+      routesBySlug.set(route.slug, route)
+    }
+  })
+
+  clonedRoutes.forEach((route) => {
+    if (route.parent) {
+      const parentRoute = routesBySlug.get(route.parent)
+
+      if (parentRoute && parentRoute !== route) {
+        parentRoute.children = [...(parentRoute.children ?? []), route]
+        return
+      }
+    }
+
+    rootRoutes.push(route)
+  })
+
+  return rootRoutes
+}

--- a/packages/outstatic/src/utils/collections/collection-tree.ts
+++ b/packages/outstatic/src/utils/collections/collection-tree.ts
@@ -37,6 +37,41 @@ export function findCollectionParent(
   )
 }
 
+export function getInvalidParentCollectionSlugs(
+  collections: CollectionType[],
+  collectionSlug: string
+) {
+  const invalidSlugs = new Set<string>([collectionSlug])
+
+  getDescendantCollectionSlugs(collections, collectionSlug).forEach((slug) => {
+    invalidSlugs.add(slug)
+  })
+
+  return invalidSlugs
+}
+
+export function getValidParentCollectionOptions(
+  collections: CollectionType[],
+  collectionSlug: string
+) {
+  const invalidSlugs = getInvalidParentCollectionSlugs(
+    collections,
+    collectionSlug
+  )
+
+  return collections.filter((collection) => !invalidSlugs.has(collection.slug))
+}
+
+export function updateCollectionParent(
+  collections: CollectionType[],
+  collectionSlug: string,
+  parent: string | null
+) {
+  return collections.map((collection) =>
+    collection.slug === collectionSlug ? { ...collection, parent } : collection
+  )
+}
+
 export function getDescendantCollectionSlugs(
   collections: CollectionType[],
   parentSlug: string

--- a/packages/outstatic/src/utils/hooks/use-collections.test.tsx
+++ b/packages/outstatic/src/utils/hooks/use-collections.test.tsx
@@ -109,7 +109,14 @@ describe('useCollections', () => {
               title: 'Posts',
               slug: 'posts',
               path: 'outstatic/content/posts',
-              children: []
+              children: [
+                {
+                  title: 'Guides',
+                  slug: 'guides',
+                  path: 'outstatic/content/posts/guides',
+                  children: []
+                }
+              ]
             }
           ])
         }
@@ -129,7 +136,13 @@ describe('useCollections', () => {
         title: 'Posts',
         slug: 'posts',
         path: 'outstatic/content/posts',
-        children: []
+        parent: null
+      },
+      {
+        title: 'Guides',
+        slug: 'guides',
+        path: 'outstatic/content/posts/guides',
+        parent: 'posts'
       }
     ])
     expect(mutateAsyncMock).not.toHaveBeenCalled()
@@ -171,7 +184,7 @@ describe('useCollections', () => {
         title: 'Posts',
         slug: 'posts',
         path: 'outstatic/content/posts',
-        children: []
+        parent: null
       }
     ]
 
@@ -196,7 +209,7 @@ describe('useCollections', () => {
         title: 'Posts',
         slug: 'posts',
         path: 'outstatic/content/posts',
-        children: []
+        parent: null
       }
     ]
 

--- a/packages/outstatic/src/utils/hooks/use-collections.ts
+++ b/packages/outstatic/src/utils/hooks/use-collections.ts
@@ -15,7 +15,12 @@ export type CollectionType = {
   title: string
   slug: string
   path: string
-  children: CollectionType[]
+  parent: string | null
+}
+
+type LegacyCollectionType = Omit<CollectionType, 'parent'> & {
+  parent?: string | null
+  children?: LegacyCollectionType[]
 }
 
 type CollectionsType = CollectionType[] | null
@@ -32,6 +37,28 @@ function filterSingletonsCollection(
   return collections.filter(
     (collection) => collection.slug !== SINGLETONS_COLLECTION_SLUG
   )
+}
+
+function normalizeCollections(
+  collections: LegacyCollectionType[] = [],
+  parent: string | null = null
+): CollectionType[] {
+  return collections.flatMap((collection) => {
+    const {
+      children = [],
+      parent: collectionParent,
+      ...collectionData
+    } = collection
+    const normalizedCollection = {
+      ...collectionData,
+      parent: collectionParent ?? parent
+    }
+
+    return [
+      normalizedCollection,
+      ...normalizeCollections(children, normalizedCollection.slug)
+    ]
+  })
 }
 
 export function useCollections(options?: UseCollectionsOptions) {
@@ -61,7 +88,9 @@ export function useCollections(options?: UseCollectionsOptions) {
         }
 
         if (collectionsObject?.text) {
-          collectionsData = JSON.parse(collectionsObject.text)
+          collectionsData = normalizeCollections(
+            JSON.parse(collectionsObject.text)
+          )
           const collections = filterSingletonsCollection(collectionsData ?? [])
 
           return collections
@@ -105,7 +134,7 @@ export function useCollections(options?: UseCollectionsOptions) {
               }),
               slug: entry.name,
               path: `${ostContent}/${entry.name}`,
-              children: []
+              parent: null
             })) as CollectionsType
 
           const oid = await fetchOid()

--- a/packages/outstatic/src/utils/hooks/use-collections.ts
+++ b/packages/outstatic/src/utils/hooks/use-collections.ts
@@ -94,6 +94,9 @@ export function useCollections(options?: UseCollectionsOptions) {
             entries: { name: string; type: string }[]
           }
 
+          // Bootstrap only scans the top level of `ostContent`, so every
+          // discovered collection is a sibling at the root — `parent: null` is
+          // correct here. Users can reorganize via the parent picker afterward.
           collectionsData = entries
             .filter(
               (entry) =>

--- a/packages/outstatic/src/utils/hooks/use-collections.ts
+++ b/packages/outstatic/src/utils/hooks/use-collections.ts
@@ -10,18 +10,12 @@ import { GET_FILE } from '@/graphql/queries/file'
 import { sentenceCase } from 'change-case'
 import { stringifyError } from '@/utils/errors/stringify-error'
 import { isGithubCredentialsError } from '@/utils/errors/is-github-credentials-error'
+import {
+  normalizeCollections,
+  type CollectionType
+} from '@/utils/collections/collection-tree'
 
-export type CollectionType = {
-  title: string
-  slug: string
-  path: string
-  parent: string | null
-}
-
-type LegacyCollectionType = Omit<CollectionType, 'parent'> & {
-  parent?: string | null
-  children?: LegacyCollectionType[]
-}
+export type { CollectionType }
 
 type CollectionsType = CollectionType[] | null
 
@@ -37,28 +31,6 @@ function filterSingletonsCollection(
   return collections.filter(
     (collection) => collection.slug !== SINGLETONS_COLLECTION_SLUG
   )
-}
-
-function normalizeCollections(
-  collections: LegacyCollectionType[] = [],
-  parent: string | null = null
-): CollectionType[] {
-  return collections.flatMap((collection) => {
-    const {
-      children = [],
-      parent: collectionParent,
-      ...collectionData
-    } = collection
-    const normalizedCollection = {
-      ...collectionData,
-      parent: collectionParent ?? parent
-    }
-
-    return [
-      normalizedCollection,
-      ...normalizeCollections(children, normalizedCollection.slug)
-    ]
-  })
 }
 
 export function useCollections(options?: UseCollectionsOptions) {

--- a/packages/outstatic/src/utils/hooks/use-document-update-effect.test.ts
+++ b/packages/outstatic/src/utils/hooks/use-document-update-effect.test.ts
@@ -85,7 +85,7 @@ describe('useDocumentUpdateEffect', () => {
           title: string
           slug: string
           path: string
-          children: []
+          parent: string | null
         }[]
       | undefined
 
@@ -107,7 +107,7 @@ describe('useDocumentUpdateEffect', () => {
         title: 'Posts',
         slug: 'posts',
         path: 'outstatic/content/posts',
-        children: []
+        parent: null
       }
     ]
 
@@ -127,7 +127,7 @@ describe('useDocumentUpdateEffect', () => {
           title: 'Posts',
           slug: 'posts',
           path: '',
-          children: []
+          parent: null
         }
       ]
     })
@@ -156,7 +156,7 @@ describe('useDocumentUpdateEffect', () => {
           title: 'Posts',
           slug: 'posts',
           path: 'outstatic/content/posts',
-          children: []
+          parent: null
         }
       ]
     })


### PR DESCRIPTION
## Summary

This PR adds first-class collection hierarchy support by storing collection relationships as flat `parent` references and rendering those relationships as nested sidebar routes.

- Add shared collection tree utilities for parent lookup, legacy nested collection normalization, descendant lookup, parent option filtering, deletion behavior, and sidebar route nesting.
- Add a parent collection picker to collection field management so users can move a collection under another collection without selecting itself or one of its descendants.
- Automatically infer the parent for newly created collections from the collection path.
- Render nested collections in the dashboard sidebar and recursively validate nested navigation route children.
- Update collection deletion to preserve child collections by default, re-parenting them one level up, with an option to delete child collections too.