### PR TITLE
Make outstatic CSS PostCSS-safe

### DIFF
--- a/.changeset/postcss-safe-outstatic-css.md
+++ b/.changeset/postcss-safe-outstatic-css.md
@@ -1,0 +1,5 @@
+---
+'outstatic': patch
+---
+
+Make `outstatic/outstatic.css` safe to import directly in Tailwind CSS v3 PostCSS projects.

--- a/apps/docs/content/docs/(latest)/(getting-started)/getting-started-with-next-js.mdx
+++ b/apps/docs/content/docs/(latest)/(getting-started)/getting-started-with-next-js.mdx
@@ -68,6 +68,8 @@ export default async function Page({
 }
 ```
 
+`outstatic/outstatic.css` is compiled CSS and can be imported directly in Tailwind CSS v3 and v4 projects.
+
 `/app/api/outstatic/[[...ost]]/route.ts` (outside the route group)
 
 ```typescript

--- a/packages/outstatic/package.json
+++ b/packages/outstatic/package.json
@@ -74,7 +74,7 @@
     "./outstatic.css": "./dist/outstatic.css"
   },
   "scripts": {
-    "build": "rm -rf dist && tsup --silent && npx @tailwindcss/cli -i ./src/styles/styles.css -o ./dist/outstatic.css",
+    "build": "rm -rf dist && tsup --silent && npx @tailwindcss/cli -i ./src/styles/styles.css -o ./dist/outstatic.css && node ./scripts/flatten-css-layers.js ./dist/outstatic.css",
     "dev": "concurrently \"tsup --watch\" \"npx @tailwindcss/cli -i ./src/styles/styles.css -o ./dist/outstatic.css --watch\"",
     "clean": "rm -rf dist",
     "test": "jest",

--- a/packages/outstatic/scripts/flatten-css-layers.js
+++ b/packages/outstatic/scripts/flatten-css-layers.js
@@ -1,0 +1,104 @@
+const fs = require('fs')
+const path = require('path')
+const postcss = require('postcss')
+
+const FORBIDDEN_AT_RULES = new Set([
+  'apply',
+  'config',
+  'custom-variant',
+  'layer',
+  'plugin',
+  'source',
+  'tailwind',
+  'theme',
+  'utility'
+])
+
+const inputPath = process.argv[2]
+
+if (!inputPath) {
+  console.error('Usage: node scripts/flatten-css-layers.js <css-file>')
+  process.exit(1)
+}
+
+const cssPath = path.resolve(process.cwd(), inputPath)
+const css = fs.readFileSync(cssPath, 'utf8')
+const root = postcss.parse(css, { from: cssPath })
+
+const layerOrder = []
+const layerBuckets = new Map()
+const unlayeredNodes = []
+
+function splitLayerParams(params) {
+  return params
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean)
+}
+
+function ensureLayer(name) {
+  if (!layerBuckets.has(name)) {
+    layerBuckets.set(name, [])
+    layerOrder.push(name)
+  }
+}
+
+root.each((node) => {
+  if (node.type !== 'atrule' || node.name !== 'layer') {
+    unlayeredNodes.push(node.clone())
+    return
+  }
+
+  const layerNames = splitLayerParams(node.params)
+
+  if (!node.nodes) {
+    layerNames.forEach(ensureLayer)
+    return
+  }
+
+  const [layerName] = layerNames
+
+  if (!layerName) {
+    unlayeredNodes.push(...node.nodes.map((child) => child.clone()))
+    return
+  }
+
+  ensureLayer(layerName)
+  layerBuckets.get(layerName).push(...node.nodes.map((child) => child.clone()))
+})
+
+const flattenedRoot = postcss.root()
+
+while (unlayeredNodes[0]?.type === 'comment') {
+  flattenedRoot.append(unlayeredNodes.shift())
+}
+
+for (const layerName of layerOrder) {
+  flattenedRoot.append(...layerBuckets.get(layerName))
+}
+
+flattenedRoot.append(...unlayeredNodes)
+
+const result = flattenedRoot.toResult({ from: cssPath, map: false }).css
+const resultRoot = postcss.parse(result, { from: cssPath })
+const remainingForbiddenAtRules = []
+
+resultRoot.walkAtRules((atRule) => {
+  if (FORBIDDEN_AT_RULES.has(atRule.name)) {
+    remainingForbiddenAtRules.push(
+      `@${atRule.name} at line ${atRule.source?.start?.line ?? '?'}`
+    )
+  }
+})
+
+if (remainingForbiddenAtRules.length > 0) {
+  console.error(
+    [
+      'outstatic.css still contains Tailwind source at-rules:',
+      ...remainingForbiddenAtRules.map((rule) => `- ${rule}`)
+    ].join('\n')
+  )
+  process.exit(1)
+}
+
+fs.writeFileSync(cssPath, result)


### PR DESCRIPTION
## Summary

Fixes the package CSS build so `outstatic/outstatic.css` is flattened after Tailwind v4 compilation and no longer ships Tailwind layer/source at-rules that Tailwind v3 PostCSS reprocesses.
This keeps `./outstatic.css` as the single default CSS export and lets Next.js apps import it directly in Tailwind v3 and v4 projects.
Adds a docs note and patch changeset for the package change.

## Validation

- `pnpm --filter outstatic build`
- `pnpm build`
- `pnpm lint`
- Isolated Next.js Tailwind v3 and Tailwind v4 builds importing `outstatic/outstatic.css`

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`
