### PR TITLE
Revert PR #70

### DIFF
--- a/.changeset/revert-scope-outstatic-styles.md
+++ b/.changeset/revert-scope-outstatic-styles.md
@@ -1,0 +1,5 @@
+---
+'outstatic': patch
+---
+
+Restore the previous Outstatic dashboard style scoping behavior.

--- a/.changeset/scope-outstatic-portals.md
+++ b/.changeset/scope-outstatic-portals.md
@@ -1,5 +1,0 @@
----
-'outstatic': patch
----
-
-Automatically scope Outstatic dashboard styles for body-level portal elements.

--- a/apps/dev/src/app/(cms)/layout.tsx
+++ b/apps/dev/src/app/(cms)/layout.tsx
@@ -5,7 +5,7 @@ export default function RootLayout({
 }) {
   return (
     <html suppressHydrationWarning>
-      <body>{children}</body>
+      <body id="outstatic">{children}</body>
     </html>
   )
 }

--- a/apps/docs/app/(cms)/layout.tsx
+++ b/apps/docs/app/(cms)/layout.tsx
@@ -5,7 +5,7 @@ export default function RootLayout({
 }) {
   return (
     <html suppressHydrationWarning>
-      <body>{children}</body>
+      <body id="outstatic">{children}</body>
     </html>
   )
 }

--- a/apps/docs/content/docs/(latest)/(getting-started)/getting-started-with-next-js.mdx
+++ b/apps/docs/content/docs/(latest)/(getting-started)/getting-started-with-next-js.mdx
@@ -45,7 +45,7 @@ Add these three files under `/app`. We recommend placing Outstatic in its own ro
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html suppressHydrationWarning>
-      <body>{children}</body>
+      <body id="outstatic">{children}</body>
     </html>
   )
 }

--- a/apps/docs/content/docs/(latest)/help/upgrading-to-v2.0.mdx
+++ b/apps/docs/content/docs/(latest)/help/upgrading-to-v2.0.mdx
@@ -23,6 +23,24 @@ export default async function Page(props: { params: Promise<{ ost: string[] }> }
 }
 ```
 
+### Styles
+
+We've added a few components which are styled using a `outstatic` css namespace (id).
+
+To make sure your dashboard works with the new styles, you should add the id to your `app/(cms)/layout.tsx`'s `body` tag.
+
+`/app/(cms)/layout.tsx`
+
+```javascript
+export default function RootLayout({ children }) {
+  return (
+    <html suppressHydrationWarning>
+      <body id="outstatic">{children}</body>
+    </html>
+  )
+}
+```
+
 ### Media Files (No code changes needed)
 
 We are now using a **Media Library** page. You will have to define a **Repo Media Path** and a **Public Media Path**. You will be prompted to set up your paths either from the Media Library page or when trying to upload an image to a document.

--- a/examples/advanced-blog/src/app/(cms)/layout.tsx
+++ b/examples/advanced-blog/src/app/(cms)/layout.tsx
@@ -9,7 +9,7 @@ export default function RootLayout({
 }) {
   return (
     <html suppressHydrationWarning>
-      <body>{children}</body>
+      <body id="outstatic">{children}</body>
     </html>
   )
 }

--- a/examples/basic-blog/src/app/(cms)/layout.tsx
+++ b/examples/basic-blog/src/app/(cms)/layout.tsx
@@ -5,7 +5,7 @@ export default function RootLayout({
 }) {
   return (
     <html suppressHydrationWarning>
-      <body>{children}</body>
+      <body id="outstatic">{children}</body>
     </html>
   )
 }

--- a/examples/docs/outstatic/content/docs/getting-started-with-next-js.mdx
+++ b/examples/docs/outstatic/content/docs/getting-started-with-next-js.mdx
@@ -114,7 +114,7 @@ Once installed, you'll need to add three files to your `/app` folder. We'll crea
 export default function RootLayout({ children }) {
   return (
     <html suppressHydrationWarning>
-      <body>{children}</body>
+      <body id="outstatic">{children}</body>
     </html>
   )
 }

--- a/examples/docs/outstatic/content/docs/upgrading-to-v2.0.mdx
+++ b/examples/docs/outstatic/content/docs/upgrading-to-v2.0.mdx
@@ -10,6 +10,24 @@ slug: 'upgrading-to-v2.0'
 
 Outstatic v2.0 offers support for Next.js 15. If you are using Next.js 14, please use v1.4.
 
+### Styles
+
+We've added a few components which are styled using a `outstatic` css namespace (id).
+
+To make sure your dashboard works with the new styles, you should add the id to your `app/(cms)/layout.tsx`'s `body` tag.
+
+`/app/(cms)/layout.tsx`
+
+```javascript
+export default function RootLayout({ children }) {
+  return (
+    <html suppressHydrationWarning>
+      <body id="outstatic">{children}</body>
+    </html>
+  )
+}
+```
+
 ### Media Files (No code changes needed)
 
 We are now using a **Media Library** page. You will have to define a **Repo Media Path** and a **Public Media Path**. You will be prompted to set up your paths either from the Media Library page or when trying to upload an image to a document.

--- a/examples/docs/src/app/(cms)/layout.tsx
+++ b/examples/docs/src/app/(cms)/layout.tsx
@@ -10,7 +10,7 @@ export default function RootLayout({
 }) {
   return (
     <html suppressHydrationWarning>
-      <body>{children}</body>
+      <body id="outstatic">{children}</body>
     </html>
   )
 }

--- a/examples/outstatic-dashboard/src/app/(cms)/layout.tsx
+++ b/examples/outstatic-dashboard/src/app/(cms)/layout.tsx
@@ -5,7 +5,7 @@ export default function RootLayout({
 }) {
   return (
     <html suppressHydrationWarning>
-      <body>{children}</body>
+      <body id="outstatic">{children}</body>
     </html>
   )
 }

--- a/examples/outstatic-dashboard/src/app/layout.tsx
+++ b/examples/outstatic-dashboard/src/app/layout.tsx
@@ -7,7 +7,7 @@ export default function RootLayout({
 }) {
   return (
     <html suppressHydrationWarning>
-      <body>{children}</body>
+      <body id="outstatic">{children}</body>
     </html>
   )
 }

--- a/packages/outstatic/src/client/pages/404.tsx
+++ b/packages/outstatic/src/client/pages/404.tsx
@@ -1,7 +1,7 @@
 export default function FourOhFour() {
   return (
     <>
-      <div data-outstatic>
+      <div id="outstatic">
         <div className="absolute bottom-10 w-full left-0 overflow-hidden z-0 md:-top-10 bg-background">
           <svg
             width="100%"

--- a/packages/outstatic/src/client/pages/_components/root-provider.tsx
+++ b/packages/outstatic/src/client/pages/_components/root-provider.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { OutstaticData } from '@/app'
+import { V2BreakingCheck } from '@/components/v2-breaking-check'
 import {
   InitialDataContext,
   setSessionUpdateCallback
@@ -57,6 +58,7 @@ function RootProviderInner({ ostData, children }: RootProviderProps) {
             <ContentLockProvider>{children}</ContentLockProvider>
           </NavigationGuardProvider>
         </QueryClientProvider>
+        <V2BreakingCheck />
       </ThemeProvider>
     </InitialDataContext.Provider>
   )

--- a/packages/outstatic/src/client/pages/index.tsx
+++ b/packages/outstatic/src/client/pages/index.tsx
@@ -5,7 +5,7 @@ import { Sidebar } from '@/components/sidebar'
 import { AdminLoading } from '@/components/admin-loading'
 import { useOutstatic, useLocalData } from '@/utils/hooks/use-outstatic'
 import { useDashboardFavicon } from '@/utils/hooks/use-dashboard-favicon'
-import { useEffect, useLayoutEffect } from 'react'
+import { useEffect } from 'react'
 import { Router } from '../router'
 import Login from './login'
 import Welcome from './welcome'
@@ -91,21 +91,6 @@ export const Main = ({ params }: { params: { ost: string[] } }) => {
 }
 
 export const OstClient = ({ ostData, params }: OstClientProps) => {
-  useLayoutEffect(() => {
-    const body = document.body
-    const previousOutstaticAttribute = body.getAttribute('data-outstatic')
-
-    body.setAttribute('data-outstatic', '')
-
-    return () => {
-      if (previousOutstaticAttribute === null) {
-        body.removeAttribute('data-outstatic')
-      } else {
-        body.setAttribute('data-outstatic', previousOutstaticAttribute)
-      }
-    }
-  }, [])
-
   useDashboardFavicon()
 
   if (ostData.missingEnvVars) {

--- a/packages/outstatic/src/client/pages/login.tsx
+++ b/packages/outstatic/src/client/pages/login.tsx
@@ -202,7 +202,7 @@ export default function Login({
         onOpenChange={setShowApiKeyDialog}
         basePath={basePath}
       />
-      <div data-outstatic>
+      <div id="outstatic">
         <LoadingBackground isLoading={isLoading}>
           <main className="relative z-10 flex h-screen items-center justify-center p-4">
             {error && loginErrors[error] ? (

--- a/packages/outstatic/src/client/pages/redirect.tsx
+++ b/packages/outstatic/src/client/pages/redirect.tsx
@@ -44,7 +44,7 @@ export default function RedirectingPage() {
 
   return (
     <>
-      <div data-outstatic>
+      <div id="outstatic">
         <LoadingBackground isLoading={true}>
           <main className="relative z-10 flex h-screen items-center justify-center p-4">
             <Card>

--- a/packages/outstatic/src/client/pages/welcome.tsx
+++ b/packages/outstatic/src/client/pages/welcome.tsx
@@ -15,7 +15,7 @@ type WelcomeProps = {
 export default function Welcome({ variables }: WelcomeProps) {
   return (
     <>
-      <div data-outstatic>
+      <div id="outstatic">
         <div className="absolute bottom-10 w-full left-0 overflow-hidden z-0 md:-top-10 bg-background">
           <svg
             width="100%"

--- a/packages/outstatic/src/components/editor/extensions/slash-command/BaseCommandList.tsx
+++ b/packages/outstatic/src/components/editor/extensions/slash-command/BaseCommandList.tsx
@@ -188,7 +188,7 @@ export const BaseCommandList = ({
   }, [selectedIndex])
 
   return items.length > 0 ? (
-    <div data-outstatic>
+    <div id="outstatic">
       <div
         id="slash-command"
         ref={commandListContainer}

--- a/packages/outstatic/src/components/editor/extensions/slash-command/ImageCommandList.tsx
+++ b/packages/outstatic/src/components/editor/extensions/slash-command/ImageCommandList.tsx
@@ -211,7 +211,7 @@ const ImageCommandList = ({
   }, [selectedIndex])
 
   return (
-    <div data-outstatic>
+    <div id="outstatic">
       {showLink ? (
         <div
           className={`flex justify-between z-50 w-96 rounded-md border bg-popover text-popover-foreground shadow-md outline-hidden p-1`}

--- a/packages/outstatic/src/components/ui/outstatic/loading-background.tsx
+++ b/packages/outstatic/src/components/ui/outstatic/loading-background.tsx
@@ -9,7 +9,7 @@ export default function LoadingBackground({
   isLoading?: boolean
 }) {
   return (
-    <div data-outstatic>
+    <div id="outstatic">
       <div className="absolute left-0 z-0 h-screen w-full overflow-hidden bg-background md:-top-10 animate-in fade-in duration-300">
         <svg
           width="100%"

--- a/packages/outstatic/src/components/v2-breaking-check.tsx
+++ b/packages/outstatic/src/components/v2-breaking-check.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogAction
+} from '@/components/ui/shadcn/alert-dialog'
+import { OUTSTATIC_VERSION } from '@/utils/constants'
+
+export const V2BreakingCheck = () => {
+  const [showOverlay, setShowOverlay] = useState(false)
+
+  useEffect(() => {
+    const bodyElement = document.body
+    const hasOutstaticBodyId = bodyElement.id.includes('outstatic')
+    const hasOutstaticRootElement = Boolean(
+      document.getElementById('outstatic')
+    )
+
+    if (!hasOutstaticBodyId && !hasOutstaticRootElement) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setShowOverlay(true)
+    }
+  }, [])
+
+  if (!showOverlay) return null
+
+  const isBeta = OUTSTATIC_VERSION.includes('canary')
+
+  return (
+    <AlertDialog open={showOverlay}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Important Outstatic Update</AlertDialogTitle>
+          <AlertDialogDescription>
+            Starting from version 2.0, Outstatic requires additional
+            configuration to work properly.
+            <br />
+            <br /> Please check the documentation for the required changes.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogAction
+            onClick={() =>
+              window.open(
+                `https://${
+                  isBeta ? 'beta.' : ''
+                }outstatic.com/docs/upgrading-to-v2.0`,
+                '_blank'
+              )
+            }
+          >
+            View Documentation
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/packages/outstatic/tailwind.config.js
+++ b/packages/outstatic/tailwind.config.js
@@ -49,7 +49,7 @@ module.exports = {
     }
   },
   // https://tailwindcss.com/docs/configuration#selector-strategy
-  important: '[data-outstatic]',
+  important: '#outstatic',
   plugins: [
     require('tailwindcss-animate'),
     require('@tailwindcss/typography'),


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Reverts PR #70, restoring the previous `#outstatic` dashboard style scoping behavior instead of the `data-outstatic` body attribute flow.
This brings back the v2 breaking-change check, restores the docs and examples that instruct users to add `id="outstatic"`, and removes the superseded changeset.
Adds a replacement patch changeset describing the restored scoping behavior.

Validation: `pnpm format` and `pnpm lint` passed; lint reported existing warnings only.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
